### PR TITLE
chore: pins reusable workflows to v0.2.0

### DIFF
--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

This PR updates the reusable workflows from `org-infra` by pinning the [v0.2.0 ](https://github.com/complytime/org-infra/releases/tag/v0.2.0).

## Related Issues

- N/A

## Review Hints

- Ensure the SHA matches in the related files
- [v0.2.0](https://github.com/complytime/org-infra/releases/tag/v0.2.0) - **SHA:** `393ab96ded06d41472526fb46ebe7a7188c422d3`

> **This PR was Assisted-by:** OpenCode with Model Opus 4.6