### PR TITLE
chore: bumps reusable workflow to v0.2.1

### DIFF
--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

This PR bumps the org-infra reusable workflows from `v0.2.0` to `v0.2.1` based on the [new release.](https://github.com/complytime/org-infra/releases/tag/v0.2.1)

## Related Issues

- N/A

## Review Hints

- Ensure matching SHA `cfd981e757253218aefb37c91969c32827e5c4b1` pinned to `# v0.2.1`
- - On VS Code or text editor at `.github/workflows` directory scope use `Ctrl+F SHA + space # v0.2.1` and ensure consistent matches 

