### PR TITLE
docs: release communication and ecosystem versioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ This repo is a living design document exploring how compliance assessment become
   - [Evaluator Coupling](docs/problems/evaluator-coupling.md) — Verification logic tied to specific tools and runtimes
   - [Cross-Framework Mapping](docs/problems/cross-framework-mapping.md) — Overlapping requirements across standards with no machine-readable mapping
   - [Evidence](docs/problems/evidence.md) — Fragmented, manual, and opaque compliance evidence
+  - [Release Communication](docs/problems/release-communication.md) — Misalignment between Go semver conventions and stakeholder expectations across a multi-repo ecosystem
+- **[docs/guides/](docs/guides/)** — Practical how-to documentation:
+  - [Compatibility Matrix](docs/guides/compatibility-matrix.md) — Validated component combinations with capability maturity levels
+  - [Ecosystem Release Process](docs/guides/ecosystem-release-process.md) — Coordinating ecosystem-wide release communication
+  - [Breaking Change Policy](docs/guides/breaking-change-policy.md) — Rules and CI enforcement for maintaining Go API compatibility
 - **[docs/plans/](docs/plans/)** — Implementation plans for accepted designs
 - **[docs/ADRs/](docs/ADRs/)** — Architecture Decision Records for crystallized decisions
-- **[docs/guides/](docs/guides/)** — Practical how-to documentation
 
 ## How to contribute
 

--- a/docs/ADRs/0007-ecosystem-release-strategy.md
+++ b/docs/ADRs/0007-ecosystem-release-strategy.md
@@ -1,0 +1,42 @@
+# ADR-0007: Ecosystem Release Strategy
+
+**Status:** accepted
+
+**Date:** 2026-06-25
+
+**Deciders:** @gvauter, @jflowers, @jpower432, @marcusburghardt
+
+## Context
+
+The complytime ecosystem spans multiple independently-released repositories (complyctl, complytime-providers, complytime-policies, complypack, org-infra, complytime). Three problems motivate this decision:
+
+1. Stakeholders misread Go semver pre-release suffixes (e.g., `v1.0.0-beta.0`) as product immaturity signals. In Go, these suffixes signal API stability commitments — not product readiness — but this distinction is lost on audiences unfamiliar with Go module conventions.
+2. No ecosystem-level coordination point exists. Each repository releases independently, and no single artifact tells stakeholders "these versions work together."
+3. Breaking change risks lack automated CI enforcement beyond existing protobuf checks.
+
+complyctl's public API surface is narrow and well-guarded: the `Provider` interface in `pkg/provider`, ~15 domain types, and generated gRPC in `api/plugin`. The `internal/` boundary protects most code from external import. Existing safeguards include the optional interface pattern, domain type insulation from protobuf, Buf breaking change detection, and frozen handshake values. The API is stable and the team is ready to proceed to v1.0.0.
+
+## Decision
+
+1. **Proceed with complyctl v1.0.0**, accepting the API stability commitment. The public API surface is narrow, well-guarded, and no breaking changes are expected.
+2. **Adopt a four-tier capability maturity model** (Alpha → Beta → Pre-GA → GA) decoupled from individual component version numbers. These terms are standard in cloud-native ecosystems and do not collide with Go semver pre-release suffixes.
+3. **Establish an ecosystem release process** triggered from the complytime repository. The compatibility matrix updates only when maintainers deliberately trigger the process after verifying integration compatibility — it is a curated sign-off, not a live dashboard.
+4. **Publish a capability-oriented compatibility matrix** on complytime.dev, rendered via Docsify alongside existing documentation.
+5. **Implement three-layer breaking change CI enforcement:**
+
+   | Layer | Tool | Catches |
+   |---|---|---|
+   | Protobuf wire | Buf breaking | Wire protocol schema changes (exists) |
+   | Go API surface | apidiff | Exported type/function/interface changes in `pkg/provider` and `api/plugin` (to implement) |
+   | Integration wire | Custom CI job | Runtime incompatibilities between compiled provider binaries and complyctl (to implement) |
+
+## Consequences
+
+- Stakeholder communication improves — capability maturity levels convey production readiness without requiring Go semver literacy.
+- Ecosystem coordination has a single home — the complytime repository becomes the release coordination point with a validated compatibility matrix.
+- Breaking change detection covers three complementary layers, catching failures that any single layer would miss.
+- Release highlights are captured at merge time via `release-highlight` PR labels, preserving context while it is fresh.
+- Maintainers take on new responsibilities: curating release highlights, triggering ecosystem releases, and maintaining the compatibility matrix. These are manual, deliberate actions — automation is traded for trust that the matrix implies validated combinations.
+- The matrix may lag behind individual component releases. The matrix footer will set this expectation explicitly.
+
+**Source:** [Release Communication Strategy proposal](../../openspec/changes/release-communication-strategy/proposal.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,11 +2,17 @@
 - [Architecture](architecture.md)
 - [Glossary](glossary.md)
 
+- **Guides**
+  - [Compatibility Matrix](guides/compatibility-matrix.md)
+  - [Ecosystem Release Process](guides/ecosystem-release-process.md)
+  - [Breaking Change Policy](guides/breaking-change-policy.md)
+
 - **Problems**
   - [Requirement Fidelity](problems/requirement-fidelity.md)
   - [Evaluator Coupling](problems/evaluator-coupling.md)
   - [Cross-Framework Mapping](problems/cross-framework-mapping.md)
   - [Evidence](problems/evidence.md)
+  - [Release Communication](problems/release-communication.md)
 
 - **Plans**
   - [ComplyPack Phase 0](plans/complypack-phase0.md)
@@ -19,3 +25,4 @@
   - [0004 gRPC Provider Plugin Architecture](ADRs/0004-grpc-provider-plugin-architecture.md)
   - [0005 Two-Stream Content Model](ADRs/0005-two-stream-content-model.md)
   - [0006 ComplyPack Content Envelope](ADRs/0006-complypack-content-envelope.md)
+  - [0007 Ecosystem Release Strategy](ADRs/0007-ecosystem-release-strategy.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -29,3 +29,13 @@ This glossary covers terms specific to ComplyTime.
 | **OCI layout** | On-disk representation of OCI artifacts (per the [OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/main/image-layout.md)). Used for caching and transport. |
 | **Provider** | An execution unit that performs data collection and/or evaluation. Discovered by filesystem convention. See [ADR-0004](ADRs/0004-grpc-provider-plugin-architecture.md). |
 | **Two-stream model** | Architectural separation between compliance content (what must be true) and assessment logic (how to verify it). Independent lifecycles, independent authorship. See [ADR-0005](ADRs/0005-two-stream-content-model.md). |
+
+## Process Terms
+
+| Term | Definition |
+|:---|:---|
+| **Capability maturity level** | A four-tier assessment of a capability's readiness across the integrated stack: Alpha (evaluation only), Beta (production with awareness), Pre-GA (stakeholder validation), GA (production supported). Describes capability readiness, not individual component versions. See [compatibility matrix](guides/compatibility-matrix.md). |
+| **Compatibility matrix** | A capability-oriented mapping of stakeholder capabilities to validated component combinations with maturity levels. Represents a point-in-time maintainer sign-off on integration testing, not a live version tracker. See [compatibility matrix](guides/compatibility-matrix.md). |
+| **Ecosystem release** | A maintainer-triggered coordination event in the complytime repository that validates a combination of component versions, gathers release highlights, updates the compatibility matrix, and publishes ecosystem release notes. Distinct from individual repository releases. See [ecosystem release process](guides/ecosystem-release-process.md). |
+| **Pre-GA** | The capability maturity level between Beta and GA. Indicates a capability is feature-complete and validated by maintainers, under stakeholder testing. Deliberately named to avoid collision with Go semver "RC" (Release Candidate) labels. See [ADR-0007](ADRs/0007-ecosystem-release-strategy.md). |
+| **Release highlight** | A cross-repo GitHub label (`release-highlight`) applied by maintainers at PR merge time to flag changes that are visible or relevant to stakeholders. Queried by the ecosystem release process to compose release notes. See [ecosystem release process](guides/ecosystem-release-process.md). |

--- a/docs/guides/breaking-change-policy.md
+++ b/docs/guides/breaking-change-policy.md
@@ -1,0 +1,76 @@
+# Breaking Change Policy
+
+complyctl is a core project in the complytime ecosystem. Its public API surface — the `Provider` interface in `pkg/provider` and the generated gRPC code in `api/plugin` — is imported by every provider implementation. A breaking change to this surface forces a `v2.0.0` release, which changes the Go import path for all consumers and triggers a cascade of updates across complytime-providers, downstream tooling, and any external integrations. This policy defines the rules that keep the API stable within v1.x.
+
+## Rules for v1.x API Stability
+
+These rules apply to all packages importable by external consumers: `pkg/provider` and `api/plugin`.
+
+### Never add methods to the `Provider` interface
+
+Adding a method to an interface breaks every existing implementation. Any type that previously satisfied `Provider` would fail to compile after the addition. Introduce new RPCs via separate optional interfaces (e.g., `Validator`) that providers can adopt incrementally. complyctl already uses this pattern.
+
+### Never remove or change the type of struct fields in public types
+
+Removing a field or changing its type breaks consumers that reference the field by name or rely on its type. Only add new fields. Additive changes are backward-compatible because existing code ignores fields it does not reference.
+
+### Never add parameters to existing exported functions
+
+Adding a parameter changes the function signature and breaks every call site. Use functional options (a variadic `...Option` parameter) to extend behavior without modifying the signature. This pattern lets callers opt in to new behavior without changing existing calls.
+
+### Never remove, rename, or reorder enum values
+
+Removing or renaming an enum value breaks consumers that match on it. Reordering changes the iota-assigned integer values, which breaks serialization and any stored data that references the old value. Only append new values at the end.
+
+### Never change protobuf field numbers or field types in existing messages
+
+Protobuf field numbers are the wire identity of each field. Changing a number or type breaks serialization compatibility with every compiled binary that uses the old definition. Assign new field numbers for new fields. Treat assigned numbers as immutable.
+
+## Existing Safeguards
+
+complyctl's architecture already includes several safeguards against accidental breaking changes.
+
+| Safeguard | What it protects | How |
+|---|---|---|
+| Optional interface pattern | Provider interface stability | New RPCs are added as separate interfaces (e.g., `Validator`), not as methods on `Provider`. Existing providers compile without changes. |
+| Domain type insulation | Public Go types from protobuf churn | `pkg/provider` defines its own domain types and converts to/from protobuf. Proto field additions do not change the public Go API. |
+| `internal/` package boundary | Implementation details from external import | Go's compiler enforces that `internal/` packages cannot be imported outside the module. Most of complyctl's code lives here. |
+| Buf FILE-level breaking change detection | Protobuf wire compatibility | `buf breaking` runs against the latest release and catches field number changes, field type changes, and RPC removals in `.proto` files. |
+| Frozen handshake values in `plugin.go` | gRPC plugin protocol compatibility | The magic cookie and handshake UUID are frozen. Changing them would prevent existing compiled providers from connecting. |
+
+## Three-Layer CI Enforcement
+
+Each category of breaking change maps to a CI detection layer. No single tool catches everything — the three layers complement each other.
+
+| Category | Detection Layer | Tool |
+|---|---|---|
+| Interface method additions | Layer 2: Go API | `apidiff` |
+| Struct field removal / type changes | Layer 2: Go API | `apidiff` |
+| Function signature changes | Layer 2: Go API | `apidiff` |
+| Exported type / constant removal | Layer 2: Go API | `apidiff` |
+| Proto field number / type changes | Layer 1: Protobuf | `buf breaking` |
+| Proto RPC removal | Layer 1: Protobuf | `buf breaking` |
+| Enum value removal / reordering | Layer 2: Go API | `apidiff` |
+| Wire serialization incompatibilities | Layer 3: Integration | Custom CI job |
+
+**Layer 1 (Protobuf)** detects schema-level changes that break the wire protocol. This layer already exists in complyctl's CI.
+
+**Layer 2 (Go API)** detects changes to exported types, functions, and interfaces in `pkg/provider` and `api/plugin`. It compares the current branch against the latest release tag using `apidiff` (`golang.org/x/exp/cmd/apidiff`).
+
+**Layer 3 (Integration)** detects runtime incompatibilities that pass static checks. It builds provider binaries from the latest complytime-providers release and runs them against the current complyctl branch, verifying that the gRPC plugin protocol remains functional across versions.
+
+## Maintainer Override
+
+When all three layers agree a change is breaking but the change is intentional, maintainers may override the CI failure. This applies to situations such as coordinated migrations with no known external consumers.
+
+An override requires:
+
+- Approval from at least two maintainers.
+- Documented justification in the PR description or a dedicated comment explaining why the breaking change is acceptable and what migration path (if any) exists for consumers.
+
+Overrides are the exception, not the norm. The CI layers exist to catch accidental breakage — they should block by default.
+
+## References
+
+- [ADR-0004: gRPC Provider Plugin Architecture](../ADRs/0004-grpc-provider-plugin-architecture.md) — provider binary model, go-plugin protocol, frozen handshake values
+- [ADR-0006: ComplyPack as Content Envelope](../ADRs/0006-complypack-content-envelope.md) — content-only OCI envelope, evaluator-id routing, provider/content separation

--- a/docs/guides/compatibility-matrix.md
+++ b/docs/guides/compatibility-matrix.md
@@ -1,0 +1,46 @@
+# Compatibility Matrix
+
+The complytime ecosystem spans multiple independently-released repositories. Each component follows its own release cadence driven by engineering needs — vulnerability patches, dependency updates, Go version bumps — not by a synchronized schedule.
+
+This matrix represents **validated integration checkpoints**: specific component versions that maintainers have tested together for each capability. Individual components may release new versions between these checkpoints. The matrix shows what has been validated as a working combination, not the latest available versions.
+
+## Maturity Levels
+
+Each capability in the matrix carries a maturity level that describes its readiness for adoption.
+
+| Level       | What It Means                                                                                                                          |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Alpha**   | Early stage. The API will change. Suitable for evaluation and feedback. Not recommended for production workloads.                       |
+| **Beta**    | Functional and tested. The API may evolve with backward compatibility. Production use is possible with awareness of potential changes.  |
+| **Pre-GA**  | Feature-complete and validated by maintainers. Under stakeholder testing. Changes are made only to resolve issues found during validation. |
+| **GA**      | Tested across the integrated stack. Stable API. Supported for production use.                                                          |
+
+## Validated Capabilities
+
+> **Note:** The table below is illustrative and shows the expected structure of the matrix once the first ecosystem release is completed. Component versions and maturity levels will be updated with validated data at that time.
+
+| Capability                         | Maturity | Validated Components                                                                                                                  | Last Validated |
+| ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| CIS Kubernetes scanning (Ampel)    | Pre-GA   | [complyctl] v1.0.0-rc.1 <br> ampel-provider ([complytime-providers] v0.x.y) <br> ampel-granular-rules ([org-infra]) 2026.07 <br> [complytime-policies] 2026.07 | TBD            |
+| NIST 800-53 assessment (OpenSCAP)  | Pre-GA   | [complyctl] v1.0.0-rc.1 <br> openscap-provider ([complytime-providers] v0.x.y) <br> [complytime-policies] 2026.07                    | TBD            |
+| OPA policy evaluation              | Alpha    | [complyctl] v1.0.0-rc.1 <br> opa-provider ([complytime-providers] v0.x.y) <br> [complytime-policies] 2026.07                         | TBD            |
+
+> **Note:** Individual components may have newer releases that are not yet part of a validated combination. Check individual repository release notes for details.
+
+## Component Release Notes
+
+| Component              | Repository                                                                             |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| complyctl              | [complytime/complyctl](https://github.com/complytime/complyctl/releases)               |
+| complytime-providers   | [complytime/complytime-providers](https://github.com/complytime/complytime-providers/releases) (Ampel, OpenSCAP, OPA providers) |
+| complytime-policies    | [complytime/complytime-policies](https://github.com/complytime/complytime-policies/releases) |
+| Ampel Granular Rules   | [complytime/org-infra](https://github.com/complytime/org-infra/releases)               |
+
+---
+
+For component roles and architecture context, see [Architecture](architecture.md).
+
+[complyctl]: https://github.com/complytime/complyctl/releases
+[complytime-providers]: https://github.com/complytime/complytime-providers/releases
+[complytime-policies]: https://github.com/complytime/complytime-policies/releases
+[org-infra]: https://github.com/complytime/org-infra/releases

--- a/docs/guides/ecosystem-release-process.md
+++ b/docs/guides/ecosystem-release-process.md
@@ -1,0 +1,186 @@
+# Ecosystem Release Process
+
+The ecosystem release process is the coordination point for communicating complytime's capabilities to stakeholders. Maintainers trigger it from the complytime repository — individual repo releases do not trigger it automatically. Each ecosystem release represents a maintainer sign-off that the referenced component versions have been integration-tested together.
+
+## When to trigger an ecosystem release
+
+Trigger an ecosystem release when a meaningful capability milestone has been reached and the component versions have been validated together. There is no fixed cadence. Release when there is something worth communicating to stakeholders.
+
+Examples of good triggers:
+- A new scanning capability is available end-to-end
+- A provider moves from Alpha to Beta maturity
+- A significant compatibility expansion (new content bundle support)
+
+Do not trigger an ecosystem release for routine maintenance (dependency bumps, internal refactoring) unless it changes what stakeholders can do.
+
+## Release process steps
+
+### Step 1: Confirm validation criteria
+
+Before updating the compatibility matrix, confirm that the component versions you intend to reference pass the minimum validation criteria:
+
+| Criterion | What to verify |
+|:---|:---|
+| Breaking change CI | All applicable breaking change CI layers pass for the referenced complyctl version |
+| Provider compatibility | Referenced provider versions are compatible with the referenced complyctl version |
+| Content bundle loading | Referenced content bundles are loadable by the referenced complyctl version |
+
+If any criterion cannot be confirmed, stop. Do not update the matrix. Record which criteria failed and resolve them before proceeding.
+
+### Step 2: Gather release highlights
+
+Query all complytime org repositories for merged PRs carrying the `release-highlight` label since the last ecosystem release tag.
+
+The "since last release" boundary is the timestamp of the most recent `ecosystem-YYYY.MM` tag in the complytime repository.
+
+Repositories to query:
+
+| Repository | Role |
+|:---|:---|
+| complyctl | Runtime client (CLI + SDK) |
+| complytime-providers | Evaluator plugins (OpenSCAP, Ampel, OPA) |
+| complytime-policies | Gemara policy bundles (OCI artifacts) |
+| complypack | Content packaging tool |
+| org-infra | CI/CD, Ampel Granular rules |
+
+Before publishing, scan recent merged PRs for missed highlights. Maintainers may have forgotten to apply the label at merge time.
+
+If no highlights exist since the last release, proceed with the release but note in the release notes that no stakeholder-visible changes occurred. The updated compatibility matrix is still valuable on its own.
+
+If the GitHub API is unavailable for any repository, do not publish. Report which repositories could not be queried and retry later.
+
+### Step 3: Update the compatibility matrix
+
+Update the compatibility matrix with the new validated component versions and maturity level assessments.
+
+Maturity level changes require PR review by at least two maintainers. Use these definitions:
+
+| Level | Meaning for stakeholders |
+|:---|:---|
+| Alpha | Evaluate — the capability exists but may change significantly |
+| Beta | Adopt with awareness — the capability is functional but not yet hardened |
+| Pre-GA | Validate — the capability is ready for stakeholder testing and feedback |
+| GA | Use in production — the capability is stable and supported |
+
+The matrix footer should state: "Individual components may have newer releases that are not yet part of a validated combination."
+
+### Step 4: Compose ecosystem release notes
+
+Write release notes using the capability-oriented format. Present changes in terms of what stakeholders can now do, not which component versions changed. Component versions appear as supporting technical metadata.
+
+Use the [release notes template](#release-notes-template) below.
+
+### Step 5: Reference recent ADRs
+
+Check the `docs/ADRs/` directory for any ADRs accepted since the last ecosystem release. Include each with a brief summary of the decision and its stakeholder impact.
+
+If no ADRs were accepted since the last release, omit the architecture decisions section from the release notes.
+
+### Step 6: Commit, tag, and publish
+
+1. Commit the updated compatibility matrix and release notes to the complytime repository.
+2. Create an ecosystem release tag following the [tagging convention](#tagging-convention).
+3. The website auto-updates via Docsify — no separate deployment step is needed.
+
+## Release highlight label convention
+
+Apply the `release-highlight` label to PRs at merge time when a change is visible or relevant to stakeholders. Apply it while context is fresh.
+
+**When to apply:**
+
+- New scanning capability
+- New provider support
+- New content format or content bundle
+- Security patch that stakeholders need to be aware of
+
+**When NOT to apply:**
+
+- Internal refactoring with no user-facing behavior change
+- Dependency bumps (unless security-relevant and stakeholder-facing)
+- CI/CD infrastructure changes
+- Documentation-only changes (unless they reflect a capability change)
+
+For security patches, use judgment: apply the label if stakeholders need to take action or be aware of the change.
+
+## Tagging convention
+
+Use date-based tags:
+
+```
+ecosystem-YYYY.MM
+```
+
+If multiple ecosystem releases occur within the same month, append a sequential suffix:
+
+```
+ecosystem-2026.07
+ecosystem-2026.07.2
+ecosystem-2026.07.3
+```
+
+The first release in a month has no suffix. The second release appends `.2`, the third `.3`, and so on.
+
+Tags enable historical comparison — maintainers and stakeholders can diff between ecosystem release tags to see what changed in the matrix and release notes.
+
+## Release notes template
+
+```markdown
+# Ecosystem Release ecosystem-YYYY.MM
+
+## Capability Summary
+
+<!-- What can stakeholders now do that they could not do before? -->
+<!-- Write 2-3 sentences summarizing the release in capability terms. -->
+
+## Highlights
+
+<!-- Gathered from PRs labeled `release-highlight`, organized by capability area. -->
+<!-- Attribute each highlight to its source repository. -->
+
+### Scanning & Evaluation
+
+- [complyctl] Description of the change
+- [complytime-providers] Description of the change
+
+### Content & Packaging
+
+- [complypack] Description of the change
+- [complytime-policies] Description of the change
+
+### Infrastructure & CI
+
+- [org-infra] Description of the change
+
+## Maturity Level Changes
+
+<!-- Include only if maturity levels changed since the last release. -->
+<!-- Example: -->
+| Capability | Previous | Current | Context |
+|:---|:---|:---|:---|
+| OPA scanning | Alpha | Beta | Passed integration testing with 3 policy bundles |
+
+## Compatibility Matrix
+
+<!-- Updated validated combination. Link to the full matrix if maintained separately. -->
+| Component | Version | Maturity |
+|:---|:---|:---|
+| complyctl | vX.Y.Z | — |
+| complytime-providers | vX.Y.Z | Per-provider (see below) |
+| complytime-policies | content-version | — |
+| complypack | vX.Y.Z | — |
+
+Individual components may have newer releases that are not yet part of
+a validated combination.
+
+## Architecture Decisions
+
+<!-- Omit this section if no ADRs were accepted since the last release. -->
+- [ADR-NNNN: Title](../ADRs/NNNN-slug.md) — Brief summary of the decision
+  and its stakeholder impact.
+
+## Individual Repository Release Notes
+
+- [complyctl vX.Y.Z](https://github.com/complytime/complyctl/releases/tag/vX.Y.Z)
+- [complytime-providers vX.Y.Z](https://github.com/complytime/complytime-providers/releases/tag/vX.Y.Z)
+- [complypack vX.Y.Z](https://github.com/complytime/complypack/releases/tag/vX.Y.Z)
+```

--- a/docs/problems/release-communication.md
+++ b/docs/problems/release-communication.md
@@ -1,0 +1,96 @@
+# Release Communication
+
+Stakeholders consuming the complytime ecosystem interpret version numbers as readiness signals. They are not — at least not in the way stakeholders expect. Go semver pre-release suffixes (`-alpha`, `-beta`, `-rc`) are API stability contracts specific to Go's module system. A fully functional capability labeled `v1.0.0-beta` is perceived as "not ready for production" by anyone unfamiliar with Go conventions. The version label says one thing to the Go toolchain and something entirely different to the person deciding whether to adopt.
+
+This problem is compounded by the ecosystem's multi-repo structure: value emerges from the composition of compatible components across repositories, but no single version number answers "can I do X?" The result is a persistent gap between sound engineering practices and stakeholder confidence — one that recurs every release cycle and scales with the ecosystem.
+
+This doc explores *why* release communication is hard in this ecosystem and what structural factors make it resistant to simple fixes. It does not propose what ComplyTime should build.
+
+This problem was identified through discussions between @gvauter, @jflowers, @jpower432, and @marcusburghardt.
+
+## The version label perception gap
+
+Go's module system assigns structural meaning to version numbers that other ecosystems do not. The distinction matters:
+
+| Version | What Go means | What stakeholders hear |
+|:---|:---|:---|
+| `v1.0.0-beta.0` | The API surface may still change. Import path is not yet locked. | "This is beta software. Not production-ready." |
+| `v1.0.0` | The API surface is stable. The import path is locked. Breaking changes require `v2.0.0`. | "This is the first stable release." |
+| `v0.x.y` | No stability guarantees. The API may change freely. | "This is pre-release." |
+
+The first and second columns are not contradictory — they describe orthogonal concerns. A component at `v1.0.0-beta.0` can be fully functional, well-tested, and used in production workflows. The pre-release suffix is a statement about API contract stability, not about whether the software works. But the distinction is invisible to anyone outside the Go ecosystem, and most stakeholders are outside the Go ecosystem.
+
+The perception gap is not a misunderstanding that documentation can fix. It is a semiotic collision: the same label carries different meanings in different contexts, and there is no mechanism to signal which meaning applies.
+
+## The Go v1.0.0 commitment
+
+In most language ecosystems, bumping from `v1.x` to `v2.0.0` is a routine major release. In Go, it is a structural event. Go modules encode the major version in the import path:
+
+```
+github.com/complytime/complyctl          // v0.x or v1.x
+github.com/complytime/complyctl/v2       // v2.x — different import path
+```
+
+Every consumer that imports `complyctl` must update their import paths when `v2.0.0` is released. For the complytime ecosystem, where [providers](../ADRs/0004-grpc-provider-plugin-architecture.md) and content tooling depend on `complyctl`'s `pkg/provider` interface and `api/plugin` gRPC definitions, a major version bump propagates across the entire [component map](../architecture.md). This makes `v1.0.0` a heavyweight decision — it is a commitment to API stability that carries real structural consequences if broken.
+
+The practical effect: maintainers are rationally cautious about dropping the pre-release suffix, even when the software is functionally complete. That caution reads as hesitation to stakeholders. The engineering prudence and the communication signal point in opposite directions.
+
+## Multi-repo coordination
+
+The complytime ecosystem spans multiple independently-released repositories:
+
+| Repository | Role | Versioning |
+|:---|:---|:---|
+| complyctl | Runtime client (CLI + SDK) | Go semver |
+| complytime-providers | Evaluator plugins (OpenSCAP, Ampel, OPA) | Go semver |
+| complytime-policies | Gemara policy bundles (OCI artifacts) | Content-versioned |
+| complypack | Content packaging tool | Go semver |
+| org-infra | CI/CD, Ampel Granular rules | Infrastructure |
+
+See [architecture.md](../architecture.md) for the component vocabulary and [ADR-0005](../ADRs/0005-two-stream-content-model.md) for the two-stream content model that governs how assessment logic and compliance content are separated.
+
+A stakeholder capability — "scan my RHEL system against NIST SP 800-53" — requires a specific combination: a `complyctl` version, a `complytime-providers` version with a functional OpenSCAP provider, and a `complytime-policies` bundle containing the relevant profile. No single repository version answers the stakeholder's question. The answer lives in the intersection of compatible versions across repositories, and that intersection is not published anywhere.
+
+Each repository releases on its own schedule. A new `complyctl` release does not imply that providers have been tested against it. A provider release does not imply that new policy bundles exist. The absence of an ecosystem-level coordination point forces stakeholders to reverse-engineer compatibility from repository tags, changelogs, and go.mod files.
+
+## Unpredictable release cadence
+
+Releases in this ecosystem are driven by engineering events, not stakeholder milestones:
+
+- A CVE in a transitive dependency triggers a patch release.
+- A new Go version requires a compatibility update.
+- A dependency bumps its minimum supported version.
+
+Any of these can produce a release tomorrow with zero new stakeholder-visible features. Conversely, a feature that stakeholders are waiting for may land in a repository without triggering an ecosystem-level announcement, because no such announcement mechanism exists.
+
+This cadence is correct for an open-source project — you release when there is something to release, not on a schedule. But it means that stakeholders cannot predict when capabilities they care about will be available in a validated combination. Tying communication to individual releases creates noise: most releases are not stakeholder-relevant, and the ones that are get lost in the stream.
+
+## Per-provider maturity asymmetry
+
+The [provider plugin architecture](../ADRs/0004-grpc-provider-plugin-architecture.md) enables multiple evaluators to coexist within `complytime-providers`. Each provider wraps a different assessment tool — OpenSCAP for OS configuration, OPA for policy-as-code, Ampel for granular checks. These providers are at different stages of maturity:
+
+| Provider | Maturity | Notes |
+|:---|:---|:---|
+| OpenSCAP | Stable | Production-tested, well-understood failure modes |
+| Ampel | Stable | Actively used, clear scope |
+| OPA | In development | Functional but interface still evolving |
+
+All three ship under a single repository version. When `complytime-providers` releases `v0.4.0`, the version tells you nothing about which providers are ready for production use. A stakeholder evaluating the OPA provider sees the same version as a stakeholder relying on OpenSCAP, but their confidence should be different.
+
+The repository version hides provider-level maturity behind a single number. There is no mechanism to surface "OpenSCAP is stable, OPA is alpha" within the versioning scheme itself — Go semver applies to the module, not to subcomponents within it.
+
+## The missing translation layer
+
+In most production software ecosystems, a downstream layer absorbs these tensions. A distribution, a managed service, or a product team selects validated combinations, assigns their own version numbers, writes stakeholder-facing release notes, and insulates adopters from upstream versioning semantics. The downstream layer translates engineering artifacts into adoption artifacts.
+
+The complytime ecosystem does not have this layer. Stakeholders consume upstream directly. They read GitHub release pages. They interpret Go version tags. They correlate repositories manually. Every tension described above — the perception gap, the multi-repo coordination problem, the cadence mismatch, the provider asymmetry — lands directly on the stakeholder without mediation.
+
+This is not unusual for open-source projects at this stage. But it means the upstream project must solve communication problems that would otherwise be absorbed by downstream productization. The upstream versioning scheme, release process, and documentation must serve double duty: they must be correct for Go tooling and comprehensible to non-Go stakeholders simultaneously.
+
+## Open questions
+
+- What is the right unit of communication — individual component releases, validated combinations, or capability milestones?
+- Can a compatibility matrix remain trustworthy if release cadence is unpredictable and integration testing is not fully automated?
+- How should per-provider maturity be declared — in code (e.g., the provider's `Describe` RPC), in documentation, or both?
+- Is a four-tier maturity model (Alpha, Beta, Pre-GA, GA) the right granularity, or does it risk recreating the same label confusion it aims to solve?
+- What mechanism triggers ecosystem-level communication when the significant event is the *combination* of releases, not any single release?

--- a/openspec/changes/release-communication-strategy/.openspec.yaml
+++ b/openspec/changes/release-communication-strategy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/release-communication-strategy/design.md
+++ b/openspec/changes/release-communication-strategy/design.md
@@ -1,0 +1,148 @@
+## Context
+
+The complytime ecosystem is a multi-repository open-source project delivering automated compliance assessment. The core repositories are:
+
+| Repository | Role | Current Version |
+|---|---|---|
+| complyctl | Runtime client (CLI + SDK) | v1.0.0-beta.0 |
+| complytime-providers | Evaluator plugins (OpenSCAP, Ampel, OPA) | v0.x.y |
+| complytime-policies | Gemara policy bundles (OCI artifacts) | content-versioned |
+| complypack | Content packaging tool | v0.x.y |
+| org-infra | CI/CD, Ampel Granular rules | infrastructure |
+| complytime (this repo) | Design docs, architecture decisions | docs-only |
+
+The primary stakeholders today are teams within the same organization, planning production adoption. However, as an open-source project, the complytime ecosystem serves a broader community of potential adopters and contributors. The communication strategy must work for all audiences, not just the current primary stakeholders. A near-term milestone exists for communicating the complyctl v1.0.0 release.
+
+This design originated from an exploratory discussion between @gvauter, @jflowers, @jpower432, and @marcusburghardt, where multiple stakeholder perspectives were examined to identify the core communication and versioning challenges.
+
+The current state has three problems:
+1. Go semver pre-release suffixes are misread as product immaturity signals by stakeholders unfamiliar with Go module versioning conventions. In Go specifically, pre-release suffixes signal API stability commitments (a `v1.0.0` locks the import path and any future breaking change forces a `v2.0.0` with import path churn for all consumers), not product readiness. This distinction is less relevant in other language ecosystems where major version bumps carry fewer structural consequences.
+2. There is no ecosystem-level coordination point. Each repo releases independently, and no single artifact tells stakeholders "these versions work together for this capability."
+3. Breaking change risks, while low and well-mitigated, lack automated CI enforcement beyond protobuf checks.
+
+complyctl is a core project in the ecosystem. Changes to complyctl's API surface directly impact all integrated projects — providers, content tooling, and downstream consumers. This central role makes its stability especially critical. Architectural decisions such as separating providers into their own repository (complytime-providers) were made specifically to reduce the blast radius of changes and keep the core as stable as possible. Further efforts in this direction are being considered to minimize coupling between the core and the broader ecosystem.
+
+complyctl's public API surface is narrow and well-architected: the `Provider` interface in `pkg/provider`, ~15 domain types, and generated gRPC code in `api/plugin`. The `internal/` package boundary protects most code from external import. Existing safeguards include the optional interface pattern for extending RPCs without breaking existing providers, domain type insulation from protobuf, Buf breaking change detection, and frozen handshake values.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Decouple capability readiness communication from individual component version numbers so stakeholders can assess production readiness without interpreting Go semver semantics.
+- Establish the complytime repository as the single coordination point for ecosystem releases, where maintainers sign off on validated combinations of component versions.
+- Define a sustainable, repeatable process for ecosystem releases that works for every release cycle, not just the first stable release milestone.
+- Automate breaking change detection across the three layers where incompatibilities can occur (protobuf wire, Go API surface, integration wire).
+- Make the compatibility matrix self-explanatory within 30 seconds to stakeholders who may not be familiar with Go module versioning conventions.
+- Support per-provider maturity levels within the complytime-providers repository, since providers within a single repo version may be at different readiness stages.
+- Account for unpredictable release cadence driven by external factors (CVEs, dependency updates, Go version bumps) in the communication model.
+
+**Non-Goals:**
+
+- Downstream distribution packaging. This proposal focuses on upstream communication and coordination. Downstream consumers may build their own integration and packaging strategies on top of the ecosystem release artifacts.
+- Automated integration testing infrastructure. The CI enforcement layers are specified at the detection level; full integration test harnesses are a separate concern.
+- External provider compatibility tracking. The matrix covers complytime-org repositories. External providers self-declare compatibility.
+- Synchronizing release cadences across repositories. Each repo continues to release independently.
+- Defining the detailed implementation of CI workflows. The proposal specifies what each CI layer detects, not the pipeline YAML.
+- Content versioning strategy for OCI artifacts (policies, complypacks). These follow their own lifecycle.
+
+## Decisions
+
+### 1. Capability maturity levels use Alpha/Beta/Pre-GA/GA terminology
+
+**Decision**: Use Alpha, Beta, Pre-GA, and GA as the four maturity tiers for capabilities in the compatibility matrix.
+
+**Rationale**: These terms are standard in the cloud-native ecosystem (Kubernetes API groups, CNCF project maturity). They are intuitive to both technical and non-technical audiences. Critically, they do not collide with Go semver pre-release suffixes (-alpha, -beta, -rc), which avoids re-entangling the version label confusion at the capability level. "Pre-GA" was chosen over "RC" (Release Candidate) specifically because RC is developer jargon tied to git tags and would recreate the same semiotic collision the matrix is designed to solve.
+
+**Alternatives considered**:
+- Using semver-aligned terms (Alpha/Beta/RC/Stable): Rejected because it re-entangles capability readiness with release labels.
+- Using readiness terms (Experimental/Ready for Testing/Production Ready): More descriptive but non-standard and verbose for matrix columns.
+- Three tiers without Pre-GA: Rejected because the validation gate between Beta and GA is a distinct, important state for stakeholder testing.
+
+### 2. The compatibility matrix is a maintainer sign-off, not a live dashboard
+
+**Decision**: The matrix updates only when maintainers trigger the ecosystem release process in the complytime repository. It is not automatically updated by individual repo releases.
+
+**Rationale**: A CVE patch in complyctl that bumps the version should not automatically update the matrix, because the new version hasn't been integration-tested with the other components. The matrix's value is that it implies "we tested these together." Automatic updates would undermine that trust signal. Maintainers deliberately trigger the process after verifying integration compatibility, making the matrix a curated checkpoint rather than a version tracker.
+
+**Alternatives considered**:
+- Auto-update on any repo release: Rejected because it implies validation that hasn't happened and creates noise from non-capability-related releases (CVE patches, dependency bumps).
+- Scheduled periodic updates (monthly): Rejected because release cadence is unpredictable and a fixed schedule doesn't align with engineering reality.
+
+### 3. Release highlights are curated via PR labels at merge time
+
+**Decision**: Maintainers apply a `release-highlight` label to PRs in any complytime org repo when the change is stakeholder-visible. The ecosystem release process queries these labels to compose release notes.
+
+**Rationale**: Curation at merge time captures context when it's fresh. The alternative — reviewing all merged PRs at ecosystem release time — requires maintainers to recall context from weeks or months prior. A single label (`release-highlight`) is the minimal overhead approach; granular label categories (highlight/feature, highlight/security, highlight/breaking) can be added later if needed.
+
+**Alternatives considered**:
+- Manual release notes composition at ecosystem release time: Higher cognitive burden, context loss, more error-prone.
+- Automated changelog generation from conventional commits: Produces developer-oriented output, not stakeholder-oriented. Lacks curation.
+- Granular label categories from the start: More structure but higher adoption friction. Starting simple with one label and evolving is lower risk.
+
+### 4. Three-layer breaking change detection in CI
+
+**Decision**: Implement breaking change detection across three layers, each catching different failure modes.
+
+| Layer | Tool | Catches | Status |
+|---|---|---|---|
+| 1. Protobuf wire | buf breaking | Proto schema changes that break wire protocol | Exists |
+| 2. Go API surface | apidiff | Changes to exported types/functions/interfaces in `pkg/provider` and `api/plugin` | To implement |
+| 3. Integration wire | Custom CI job | Runtime incompatibilities between compiled provider binaries and new complyctl | To implement |
+
+**Rationale**: Each layer catches failures the others miss. Buf catches proto breaks but not Go type changes. Apidiff catches Go API breaks but not wire-level serialization issues. Integration tests catch subtle runtime incompatibilities that pass static checks. The existing `test-provider` and `behavioral-report` commands in complyctl provide a foundation for Layer 3.
+
+**Alternatives considered**:
+- Buf breaking only (Layer 1): Already in place but insufficient. Doesn't catch Go API changes that don't originate from proto definitions.
+- Apidiff only (Layer 2): Catches Go API breaks but misses proto wire issues and runtime incompatibilities.
+- Full integration test suite: Desirable long-term but too heavy for the first stable release timeline. Layer 3 is a lightweight version focused specifically on backward compatibility.
+
+### 5. Ecosystem release artifacts live in the complytime repository
+
+**Decision**: The compatibility matrix, ecosystem release notes, and the release process definition all live in this repository (complytime) and are rendered on complytime.dev via Docsify.
+
+**Rationale**: This repository is already the design and architecture home. It uses Docsify for web rendering at complytime.dev. Placing ecosystem release artifacts here makes the complytime repo the single coordination point and avoids creating a new repository for release management. The matrix becomes a markdown file in `docs/guides/` that Docsify renders, maintaining consistency with the existing documentation structure.
+
+**Alternatives considered**:
+- Separate release-management repository: More isolation but adds coordination overhead and fragments the documentation.
+- In each individual repo: Defeats the purpose of ecosystem-level coordination.
+- External platform (wiki, Notion): Breaks the docs-as-code model and complicates automation.
+
+## Risks / Trade-offs
+
+### [Risk] Maturity level disagreements between maintainers
+Different maintainers may assess the same capability's readiness differently, leading to inconsistent or contentious maturity assignments.
+**Mitigation**: Maturity level changes require PR review by at least two maintainers (matching the existing ADR approval gate). The maturity definitions provide objective criteria. Disagreements are resolved through the standard PR review process.
+
+### [Risk] Label adoption friction
+Maintainers may forget to apply `release-highlight` labels, resulting in incomplete ecosystem release notes.
+**Mitigation**: Start with a single label to minimize overhead. The ecosystem release process can include a review step where maintainers scan recent merged PRs for missed highlights before publishing. Over time, PR templates can include a reminder.
+
+### [Risk] Matrix staleness
+If ecosystem releases happen infrequently, the matrix may lag behind the actual state of the ecosystem, frustrating stakeholders who know newer versions exist.
+**Mitigation**: The matrix footer explicitly states "Individual components may have newer releases that are not yet part of a validated combination." This sets the expectation that the matrix is a checkpoint, not real-time tracking. Maintainers commit to triggering ecosystem releases at meaningful capability milestones.
+
+### [Risk] Pre-GA creates another label to misinterpret
+Introducing a Pre-GA maturity level adds a new term that stakeholders might confuse with other terminology.
+**Mitigation**: The maturity level definitions are published alongside the matrix on complytime.dev. The definitions use plain language focused on what the stakeholder should do (evaluate, adopt with awareness, validate, use in production), not on internal engineering states.
+
+### [Risk] Breaking change CI adds merge friction
+Apidiff and integration wire tests may flag changes that are intentional, blocking PRs unnecessarily.
+**Mitigation**: Both CI layers include a maintainer override escape hatch. The check warns rather than hard-blocks, and maintainers can merge with documented justification. The breaking change policy documents when overrides are appropriate (e.g., no known external consumers, coordinated migration).
+
+### [Trade-off] Manual ecosystem release trigger vs. automation
+The deliberate choice of manual triggering means maintainers must remember to trigger ecosystem releases. This trades convenience for trust (the matrix always implies validation happened).
+**Accepted**: The alternative (automatic triggers) undermines the sign-off semantics. The risk of infrequent updates is lower than the risk of publishing untested combinations.
+
+### [Trade-off] Single `release-highlight` label vs. granular categories
+Starting with one label means ecosystem release notes lack automatic categorization (features vs. security vs. breaking changes). Maintainers must organize highlights manually during the release process.
+**Accepted**: Low adoption friction outweighs categorization convenience. Granular labels can be introduced when the process is mature and the cost of manual categorization becomes demonstrable.
+
+## Resolved Questions
+
+1. **Ecosystem release cadence**: Maintainers define an initial cadence but adapt it to reality and stakeholder demand over time. The process should be flexible and easy to adjust without friction — no rigid schedule that forces releases without meaningful changes or blocks releases when they are needed. The cadence is a guideline, not a constraint.
+
+2. **Tagging convention for ecosystem releases**: Date-based tags (e.g., `ecosystem-2026.07`) are preferred as they are intuitive for the targeted consumers of this information. Like the cadence, the convention should be easy to adapt without friction if a different scheme proves more practical over time.
+
+3. **Provider maturity declaration mechanism**: Multiple sources of maturity information should coexist. Automated signals such as the provider's `Describe` RPC response can report a self-declared maturity level. However, maturity can also change based on factors outside the code — for example, a provider that has been tested over time with no bugs found may be promoted without code changes. The matrix-side declaration in this repo serves as the authoritative source, informed by both automated signals and maintainer judgment. This keeps the mechanism flexible as the ecosystem evolves.
+
+4. **Cross-org label querying permissions**: All complytime repositories are public. Querying labels and PRs across public repositories requires only read access, which is available without special token permissions. The ecosystem release process can use the GitHub API with default public read access.

--- a/openspec/changes/release-communication-strategy/proposal.md
+++ b/openspec/changes/release-communication-strategy/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The complytime ecosystem spans multiple independently-released repositories (complyctl, complytime-providers, complytime-policies, complypack, org-infra). Stakeholders consuming these upstream projects interpret Go semver pre-release suffixes (-alpha, -beta, -rc) as product maturity signals, when they are actually API stability contracts specific to Go's module system. This creates persistent misalignment between sound engineering practices and business expectations, eroding stakeholder confidence despite features being functional and delivered.
+
+The problem is compounded by three factors: (1) there is no ecosystem-level translation layer between upstream release practices and stakeholder expectations, so adopters must interpret individual repository versions directly; (2) release cadence is driven by engineering needs (vulnerability patches, dependency updates, Go version bumps) not stakeholder feature requests, so releases may happen with no stakeholder-visible changes; and (3) individual providers within complytime-providers have different maturity levels, invisible behind a single repository version number. Without a deliberate strategy, this misalignment will recur every release cycle and scale with the ecosystem.
+
+The immediate trigger is an agreed deadline to have the first stable release of complyctl out by July 8th. The API surface is stable, no breaking changes are expected, and the pre-release suffix is precautionary. The team needs both a pragmatic short-term approach for this milestone and a sustainable long-term framework.
+
+## What Changes
+
+- **Ecosystem release process**: Introduce a maintainer-triggered release process in the complytime repository that serves as the single coordination point for ecosystem-wide communication. This process gathers release highlights from all project repos, updates the compatibility matrix, and publishes to complytime.dev.
+- **Compatibility matrix**: Create a capability-oriented compatibility matrix that maps stakeholder-meaningful capabilities to validated component combinations with explicit maturity levels (Alpha, Beta, Pre-GA, GA). Hosted on complytime.dev, rendered from this repository, updated only through the ecosystem release process as a maintainer sign-off.
+- **Capability maturity levels**: Define a four-tier maturity model (Alpha, Beta, Pre-GA, GA) that describes capability readiness across the integrated stack, deliberately decoupled from individual component version numbers. Per-provider maturity levels within complytime-providers are surfaced independently.
+- **Breaking change policy and CI enforcement**: Document the rules for maintaining Go API compatibility within v1.x and implement automated detection. Three layers: protobuf wire compatibility (buf breaking, already exists), Go API surface compatibility (apidiff, to implement), and integration wire testing (old provider binary vs. new complyctl, to implement).
+- **Release highlight labeling**: Establish a cross-repo labeling convention (e.g., `release-highlight`) that maintainers apply at PR merge time to flag stakeholder-visible changes. The ecosystem release process queries these labels to compose release notes automatically.
+- **Stakeholder communication template**: Define a reusable capability-oriented communication format that presents ecosystem value in stakeholder language, with component versions as supporting technical metadata rather than headlines.
+
+## Capabilities
+
+### New Capabilities
+
+- `ecosystem-release-process`: The maintainer-triggered workflow in the complytime repository that coordinates matrix updates, gathers highlights, composes release notes, and publishes to complytime.dev. Includes the labeling convention for release highlights across repos.
+- `compatibility-matrix`: The capability-oriented matrix mapping stakeholder capabilities to validated component combinations with maturity levels. Includes the maturity level definitions (Alpha, Beta, Pre-GA, GA), matrix schema, hosting on complytime.dev, and the principle that the matrix is a maintainer sign-off on integration testing.
+- `breaking-change-governance`: The policy document defining rules for Go API compatibility within v1.x, the three-layer CI enforcement model (buf breaking, apidiff, integration wire test), and the escape hatch for maintainer overrides.
+
+### Modified Capabilities
+
+(none - no existing specs to modify)
+
+### Removed Capabilities
+
+(none)
+
+## Constitution Alignment
+
+No org constitution file (`.specify/memory/constitution.md`) exists for this repository. Constitution assessments are not applicable. The change aligns with the project's documented principles in `docs/vision.md` (Fidelity, Decoupling, Composability).
+
+## Impact
+
+- **This repository (complytime)**: New documentation artifacts (problem doc, ADR, guides). Compatibility matrix file added and rendered via Docsify on complytime.dev. Possible GitHub Actions workflow for the ecosystem release process.
+- **complyctl**: CI pipeline additions for apidiff and integration wire testing. No code changes to the application itself. Release process for v1.0.0-rc.1 and v1.0.0 by the agreed stable release date.
+- **complytime-providers**: Per-provider maturity level declarations. Release highlight labeling convention adopted by maintainers.
+- **complytime-policies, complypack, org-infra**: Release highlight labeling convention adopted. No other direct changes.
+- **complytime.dev**: New compatibility matrix page rendered from this repo. Ecosystem release notes page.
+- **Stakeholder communication**: Shift from per-repo version announcements to capability-oriented ecosystem release notes. Explicit maturity definitions replace implicit version-number interpretation.
+- **Cross-repo coordination**: GitHub label convention (`release-highlight`) established across all complytime org repos. Ecosystem release process in this repo queries labels from other repos.

--- a/openspec/changes/release-communication-strategy/specs/breaking-change-governance/spec.md
+++ b/openspec/changes/release-communication-strategy/specs/breaking-change-governance/spec.md
@@ -1,0 +1,99 @@
+This spec defines the requirements for the breaking change policy, the three-layer CI enforcement model protecting complyctl's Go API surface, and the maintainer override escape hatch for intentional changes.
+
+## ADDED Requirements
+
+### Requirement: Breaking change policy documents rules for v1.x API stability
+A breaking change policy document SHALL be published as a guide in the complytime repository. It SHALL define what constitutes a breaking change in the Go API surface of complyctl and SHALL provide actionable rules for contributors to maintain backward compatibility within the v1.x major version line.
+
+#### Scenario: Policy covers interface changes
+- **WHEN** a contributor reviews the breaking change policy
+- **THEN** the policy SHALL state that methods MUST NOT be added to the `Provider` interface and that new RPCs MUST be introduced via separate optional interfaces
+
+#### Scenario: Policy covers struct field changes
+- **WHEN** a contributor reviews the breaking change policy
+- **THEN** the policy SHALL state that struct fields in public types (`pkg/provider`, `api/plugin`) MUST NOT be removed or have their types changed, and that new fields MUST only be added (additive changes)
+
+#### Scenario: Policy covers function signature changes
+- **WHEN** a contributor reviews the breaking change policy
+- **THEN** the policy SHALL state that existing exported function signatures MUST NOT have parameters added or removed, and that extensibility MUST be achieved via functional options patterns (variadic parameters)
+
+#### Scenario: Policy covers enum value changes
+- **WHEN** a contributor reviews the breaking change policy
+- **THEN** the policy SHALL state that enum values MUST NOT be removed, renamed, or reordered, and that new values MUST only be appended
+
+#### Scenario: Policy covers protobuf field numbers
+- **WHEN** a contributor reviews the breaking change policy
+- **THEN** the policy SHALL state that protobuf field numbers are immutable once assigned, and that field types MUST NOT be changed in existing messages
+
+### Requirement: Go API surface compatibility is checked in CI
+complyctl CI SHALL include an automated check that compares the current branch's exported Go API surface against the latest release tag. The check SHALL use `apidiff` (golang.org/x/exp/cmd/apidiff) or an equivalent tool. The check SHALL cover all packages importable by external consumers: `pkg/provider` and `api/plugin`.
+
+#### Scenario: Non-breaking change passes CI
+- **WHEN** a PR adds a new exported type `ValidateRequest` to `pkg/provider` without modifying existing types
+- **THEN** the apidiff CI check SHALL pass, reporting the change as compatible
+
+#### Scenario: Breaking change detected in CI
+- **WHEN** a PR adds a `Validate` method to the `Provider` interface in `pkg/provider`
+- **THEN** the apidiff CI check SHALL fail, reporting that the change breaks the `Provider` interface for existing implementors
+
+#### Scenario: Breaking change with maintainer override
+- **GIVEN** a PR contains a breaking change that is intentional and justified (e.g., no known external consumers, coordinated migration planned)
+- **WHEN** a maintainer invokes the override for a breaking change CI failure
+- **THEN** the PR SHALL require approval from at least two maintainers, and the override justification SHALL be recorded in the PR description or a dedicated comment
+
+### Requirement: Protobuf wire compatibility is checked in CI
+complyctl CI SHALL include an automated check that detects breaking changes in protobuf definitions. This check SHALL use Buf with `FILE`-level breaking change detection, comparing the current branch against the latest release.
+
+#### Scenario: Proto field number change detected
+- **WHEN** a PR changes the field number of an existing field in `plugin.proto`
+- **THEN** the buf breaking CI check SHALL fail
+
+#### Scenario: New proto field added
+- **WHEN** a PR adds a new field to an existing message in `plugin.proto` with a new field number
+- **THEN** the buf breaking CI check SHALL pass
+
+#### Scenario: New RPC added to service
+- **WHEN** a PR adds a new RPC to the Plugin service in `plugin.proto`
+- **THEN** the buf breaking CI check SHALL pass (additive change)
+
+### Requirement: Integration wire compatibility is tested in CI
+complyctl CI SHALL include a job that tests backward compatibility at the wire level by building provider binaries from the latest released version of complytime-providers and running them against the current branch of complyctl. This test SHALL verify that the gRPC plugin protocol remains functional across versions.
+
+#### Scenario: Old provider works with new complyctl
+- **WHEN** the integration wire test runs with provider binaries built from the latest complytime-providers release tag against the current complyctl PR branch
+- **THEN** the Describe, Generate, and Scan RPCs SHALL all complete without transport errors
+
+#### Scenario: Wire incompatibility detected
+- **WHEN** a change in complyctl breaks the gRPC serialization or handshake with older provider binaries
+- **THEN** the integration wire test SHALL fail, indicating that the change would break existing compiled providers
+
+#### Scenario: Test uses existing test infrastructure
+- **WHEN** the integration wire test is implemented
+- **THEN** it SHALL leverage the existing `test-provider` and `behavioral-report` commands in complyctl's `cmd/` directory as foundations, minimizing new test infrastructure
+
+#### Scenario: Provider release artifacts are unavailable
+- **GIVEN** the integration wire test depends on building provider binaries from the latest complytime-providers release tag
+- **WHEN** no release tags exist in complytime-providers or the latest tag fails to build
+- **THEN** the integration wire test SHALL skip with an informational warning rather than failing the CI check, and SHALL report which provider artifact could not be resolved
+
+### Requirement: Breaking change categories are mapped to detection layers
+The breaking change policy SHALL include a mapping table that connects each category of breaking change to the CI layer responsible for detecting it. This mapping SHALL serve as a reference for both contributors (understanding what is checked) and maintainers (verifying CI coverage).
+
+#### Scenario: Contributor looks up what CI catches
+- **WHEN** a contributor wants to know if their change to a struct field type in `pkg/provider` will be caught by CI
+- **THEN** the mapping table SHALL show that struct field type changes are detected by the apidiff CI layer (Layer 2)
+
+#### Scenario: Mapping covers all breaking change categories
+- **WHEN** the mapping table is reviewed
+- **THEN** it SHALL cover at minimum: interface method additions, struct field removal/type changes, function signature changes, exported type/constant removal, proto field number/type changes, proto RPC removal, enum value removal/reordering, and wire-level serialization incompatibilities
+
+### Requirement: Breaking change policy references existing safeguards
+The policy document SHALL acknowledge and reference the safeguards already in place in complyctl's codebase, including the optional interface pattern for extending RPCs, domain type insulation from protobuf, internal package boundaries, Buf breaking detection configuration, and frozen handshake values.
+
+#### Scenario: Existing safeguards are documented
+- **WHEN** a new contributor reads the breaking change policy
+- **THEN** they SHALL find a section listing the existing architectural safeguards with explanations of how each one protects against specific categories of breaking changes
+
+#### Scenario: Policy connects to architecture decisions
+- **WHEN** the breaking change policy references the provider plugin architecture
+- **THEN** it SHALL link to ADR-0004 (gRPC Provider Plugin Architecture) and ADR-0006 (ComplyPack as Content Envelope) for architectural context

--- a/openspec/changes/release-communication-strategy/specs/compatibility-matrix/spec.md
+++ b/openspec/changes/release-communication-strategy/specs/compatibility-matrix/spec.md
@@ -1,0 +1,89 @@
+This spec defines the requirements for the capability-oriented compatibility matrix that maps stakeholder-meaningful capabilities to validated component combinations with explicit maturity levels, hosted on complytime.dev.
+
+## ADDED Requirements
+
+### Requirement: Compatibility matrix maps capabilities to validated component combinations
+The compatibility matrix SHALL present ecosystem readiness as a mapping from stakeholder-meaningful capabilities to specific validated component versions. The matrix SHALL NOT be organized by repository or component; it SHALL be organized by what the stakeholder can do.
+
+#### Scenario: Stakeholder looks up a capability
+- **WHEN** a stakeholder wants to know if CIS Kubernetes scanning is production-ready
+- **THEN** they SHALL find a single row in the matrix showing the capability name, its maturity level, and the exact component versions validated for that capability
+
+#### Scenario: Multiple capabilities share components
+- **WHEN** CIS Kubernetes scanning and NIST 800-53 assessment both require complyctl v1.0.0
+- **THEN** complyctl v1.0.0 SHALL appear in both capability rows, and the stakeholder SHALL see that each capability has its own independent maturity level
+
+### Requirement: Compatibility matrix uses four-tier maturity levels
+The matrix SHALL use exactly four maturity levels: Alpha, Beta, Pre-GA, and GA. Each level SHALL have a published definition focused on stakeholder action, not internal engineering state.
+
+#### Scenario: Maturity level definitions are accessible
+- **WHEN** a stakeholder reads the compatibility matrix on complytime.dev
+- **THEN** the maturity level definitions SHALL be visible on the same page or immediately linked, with plain-language descriptions of what each level means for adoption decisions
+
+#### Scenario: Alpha capability in the matrix
+- **WHEN** a capability is listed with maturity level Alpha
+- **THEN** the definition SHALL communicate that the capability is early stage, the API will change, it is suitable for evaluation and feedback only, and it is not recommended for production workloads
+
+#### Scenario: Beta capability in the matrix
+- **WHEN** a capability is listed with maturity level Beta
+- **THEN** the definition SHALL communicate that the capability is functional and tested, the API may evolve with backward compatibility, and production use is possible with awareness of potential changes
+
+#### Scenario: Pre-GA capability in the matrix
+- **WHEN** a capability is listed with maturity level Pre-GA
+- **THEN** the definition SHALL communicate that the capability is feature-complete and validated by maintainers, is under stakeholder testing, and changes will only be made to resolve issues found during validation
+
+#### Scenario: GA capability in the matrix
+- **WHEN** a capability is listed with maturity level GA
+- **THEN** the definition SHALL communicate that the capability is tested across the integrated stack, has a stable API, and is supported for production use
+
+### Requirement: Compatibility matrix surfaces per-provider maturity
+Individual providers within the complytime-providers repository SHALL have their maturity levels tracked independently. The repository version number SHALL NOT be used as a proxy for individual provider maturity.
+
+#### Scenario: Providers at different maturity levels
+- **WHEN** the OpenSCAP provider is GA, the Ampel provider is Beta, and the OPA provider is Alpha
+- **THEN** each provider-backed capability SHALL show its own maturity level in the matrix, regardless of the complytime-providers repository version being the same for all three
+
+#### Scenario: Provider matures without repo version change
+- **WHEN** the Ampel provider reaches GA maturity at the same complytime-providers repo version
+- **THEN** the matrix SHALL reflect the new maturity level for the Ampel-backed capability without requiring a new repo release
+
+### Requirement: Compatibility matrix is a point-in-time validated snapshot
+The matrix SHALL represent a specific validated combination of component versions at a point in time. It SHALL NOT represent the latest available versions of each component. The matrix SHALL explicitly communicate this distinction to readers.
+
+#### Scenario: Newer component versions exist
+- **WHEN** complyctl v1.0.1 has been released as a CVE patch but the last ecosystem release validated complyctl v1.0.0
+- **THEN** the matrix SHALL still show complyctl v1.0.0, and a footnote SHALL indicate that individual components may have newer releases not yet part of a validated combination
+
+#### Scenario: Validation date is visible
+- **WHEN** a stakeholder reads the compatibility matrix
+- **THEN** the date of the last ecosystem release (validation checkpoint) SHALL be clearly displayed
+
+### Requirement: Compatibility matrix is hosted on complytime.dev
+The compatibility matrix SHALL be maintained as a markdown file in the complytime repository and rendered on complytime.dev via Docsify. The matrix SHALL be accessible from the site navigation.
+
+#### Scenario: Matrix is accessible via website
+- **WHEN** a stakeholder navigates to complytime.dev
+- **THEN** the compatibility matrix SHALL be reachable from the site navigation (sidebar) within one click
+
+#### Scenario: Matrix source is in the complytime repo
+- **WHEN** a maintainer needs to update the matrix
+- **THEN** the update SHALL be made via a PR to the complytime repository, following the standard review process
+
+### Requirement: Compatibility matrix has minimal required fields
+The matrix SHALL contain exactly four columns to minimize cognitive load: Capability, Maturity, Validated Components, and Last Validated date. Additional detail SHALL be available via links to individual repo release notes, not embedded in the matrix itself.
+
+#### Scenario: Matrix is compact and self-contained
+- **GIVEN** a stakeholder unfamiliar with Go module versioning conventions
+- **WHEN** they open the compatibility matrix on complytime.dev
+- **THEN** the matrix SHALL fit in a single rendered page section without horizontal scrolling, each capability SHALL be assessable without consulting a separate glossary, and maturity level definitions SHALL be on-page rather than linked to a separate document
+
+#### Scenario: Technical details are linked, not inlined
+- **WHEN** a stakeholder wants more detail about a specific component version change
+- **THEN** the matrix SHALL link to the individual repo's release notes for that version, rather than including detailed changelogs inline
+
+### Requirement: Compatibility matrix accounts for external factors in release cadence
+The matrix documentation SHALL acknowledge that component release cadence is driven by engineering needs including vulnerability patches, dependency updates, and Go version bumps, not by stakeholder feature timelines. This context SHALL be visible to matrix readers.
+
+#### Scenario: Context about release cadence is provided
+- **WHEN** a stakeholder reads the compatibility matrix page
+- **THEN** an introductory section SHALL explain that component versions follow independent release cadences driven by engineering best practices and external factors, and that the matrix represents validated integration checkpoints regardless of individual component release frequency

--- a/openspec/changes/release-communication-strategy/specs/ecosystem-release-process/spec.md
+++ b/openspec/changes/release-communication-strategy/specs/ecosystem-release-process/spec.md
@@ -1,0 +1,104 @@
+This spec defines the requirements for the maintainer-triggered ecosystem release process that coordinates communication across all complytime repositories and publishes validated combinations to complytime.dev.
+
+## ADDED Requirements
+
+### Requirement: Ecosystem release is triggered from the complytime repository
+The ecosystem release process SHALL be initiated by maintainers through a deliberate action in the complytime repository (e.g., a GitHub Actions workflow dispatch or a documented manual process). Individual repository releases SHALL NOT automatically trigger an ecosystem release. The ecosystem release represents a maintainer sign-off that the referenced component versions have been integration-tested together.
+
+#### Scenario: Maintainer triggers ecosystem release
+- **GIVEN** the complytime ecosystem has multiple independently-released repositories
+- **WHEN** a maintainer triggers the ecosystem release process in the complytime repository
+- **THEN** the process SHALL gather release highlights, update the compatibility matrix, compose ecosystem release notes, and publish updates to complytime.dev
+
+#### Scenario: Individual repo release does not trigger ecosystem release
+- **GIVEN** a new release has been tagged in complyctl, complytime-providers, or any other ecosystem repository
+- **WHEN** the release event is processed
+- **THEN** the compatibility matrix and ecosystem release notes SHALL NOT be automatically updated
+
+### Requirement: Ecosystem release requires minimum validation criteria
+Before updating the compatibility matrix with a new validated combination, the ecosystem release process SHALL require confirmation that the referenced component versions have been tested together. At minimum, the validation SHALL include: (1) all applicable breaking change CI layers pass for the referenced complyctl version, (2) the referenced provider versions are compatible with the referenced complyctl version, and (3) the referenced content bundles are loadable by the referenced complyctl version.
+
+#### Scenario: Validation criteria met before matrix update
+- **GIVEN** a maintainer has triggered the ecosystem release process
+- **WHEN** the process updates the compatibility matrix with new component versions
+- **THEN** the maintainer SHALL have confirmed that the minimum validation criteria are satisfied for the referenced combination
+
+#### Scenario: Validation criteria not met
+- **GIVEN** a maintainer has triggered the ecosystem release process
+- **WHEN** one or more validation criteria cannot be confirmed for the intended component versions
+- **THEN** the process SHALL NOT update the compatibility matrix and SHALL report which criteria were not satisfied
+
+### Requirement: Release highlights are gathered from labeled PRs across repos
+The ecosystem release process SHALL query all complytime org repositories for merged PRs and issues carrying the `release-highlight` label since the last ecosystem release tag. The "since last release" boundary SHALL be determined by the timestamp of the most recent ecosystem release tag in the complytime repository. The gathered highlights SHALL be used to compose the stakeholder-facing ecosystem release notes.
+
+#### Scenario: Highlights exist across multiple repos
+- **GIVEN** the last ecosystem release was tagged as `ecosystem-2026.07` and complyctl has 3 PRs labeled `release-highlight` and complytime-providers has 1 PR labeled `release-highlight` merged since that tag
+- **WHEN** the ecosystem release process runs
+- **THEN** all 4 highlights SHALL be included in the ecosystem release notes, attributed to their source repository
+
+#### Scenario: No highlights exist since last release
+- **GIVEN** the last ecosystem release was tagged and no PRs with `release-highlight` label have been merged since that tag
+- **WHEN** the ecosystem release process runs
+- **THEN** the ecosystem release notes SHALL indicate that no stakeholder-visible changes occurred and SHALL still include the updated compatibility matrix
+
+#### Scenario: GitHub API is unavailable during release process
+- **GIVEN** the ecosystem release process requires querying GitHub for labeled PRs across repositories
+- **WHEN** the process cannot query one or more repositories for release highlights
+- **THEN** the process SHALL report which repositories could not be queried and SHALL NOT publish ecosystem release notes until all repositories have been successfully queried
+
+### Requirement: Release highlight label convention
+Maintainers SHALL apply the `release-highlight` label to PRs in any complytime org repository when the change is visible or relevant to stakeholders. The label SHALL be applied at merge time when context is fresh. The label convention SHALL be documented in each repository's contributing guide.
+
+#### Scenario: Stakeholder-visible feature merged
+- **GIVEN** a PR adds a new compliance scanning capability
+- **WHEN** a maintainer merges the PR
+- **THEN** the maintainer SHALL apply the `release-highlight` label to the PR
+
+#### Scenario: Internal refactoring merged
+- **GIVEN** a PR refactors internal code without changing user-facing behavior
+- **WHEN** a maintainer merges the PR
+- **THEN** the maintainer SHALL NOT apply the `release-highlight` label
+
+#### Scenario: Security patch with stakeholder impact
+- **GIVEN** a PR patches a CVE affecting a dependency used in compliance scanning
+- **WHEN** a maintainer merges the PR
+- **THEN** the maintainer SHALL use judgment to decide whether the `release-highlight` label applies, based on whether stakeholders need to be aware of the change
+
+### Requirement: Ecosystem release notes follow capability-oriented format
+The ecosystem release notes SHALL present changes in terms of capabilities delivered, not component versions. Component versions SHALL appear as supporting technical metadata. The format SHALL be reusable across release cycles without reinvention. The release notes SHALL include placeholder sections for: capability summary, highlights organized by capability area, maturity level changes, the updated compatibility matrix, and links to individual repo release notes.
+
+#### Scenario: Release notes structure
+- **GIVEN** the ecosystem release process has gathered highlights and updated the compatibility matrix
+- **WHEN** ecosystem release notes are composed
+- **THEN** the notes SHALL include: a capability-oriented summary of changes, highlights gathered from labeled PRs organized by capability area, any maturity level changes for capabilities, the updated compatibility matrix, and references to individual repo release notes for detailed changelogs
+
+#### Scenario: Maturity level change is communicated
+- **GIVEN** a capability's maturity level has changed since the last ecosystem release (e.g., OPA scanning moved from Alpha to Beta)
+- **WHEN** ecosystem release notes are composed
+- **THEN** the notes SHALL explicitly highlight the maturity transition with context on what changed
+
+### Requirement: Ecosystem release creates a checkpoint tag in the complytime repository
+Each ecosystem release SHALL be recorded as a tag in the complytime repository to mark the point-in-time state of ecosystem documentation, matrix, and release notes. The tag SHALL follow the date-based format `ecosystem-YYYY.MM` where `YYYY.MM` is the release year and month. If multiple ecosystem releases occur within the same month, a sequential suffix SHALL be appended (e.g., `ecosystem-2026.07.2`).
+
+#### Scenario: Ecosystem release is tagged
+- **GIVEN** the ecosystem release process has completed successfully
+- **WHEN** all artifacts have been committed and published
+- **THEN** a tag following the `ecosystem-YYYY.MM[.N]` format SHALL be created in the complytime repository
+
+#### Scenario: Tag enables historical comparison
+- **GIVEN** multiple ecosystem release tags exist in the complytime repository
+- **WHEN** a stakeholder or maintainer wants to compare the current ecosystem state with a prior release
+- **THEN** they SHALL be able to diff between ecosystem release tags to see what changed in the matrix and release notes
+
+### Requirement: Ecosystem release includes recent architecture decisions
+The ecosystem release notes SHALL reference any ADRs accepted in the complytime repository since the last ecosystem release, providing stakeholders with visibility into architectural direction changes.
+
+#### Scenario: New ADR accepted since last release
+- **GIVEN** ADR-0007 was accepted between ecosystem release N and ecosystem release N+1
+- **WHEN** ecosystem release N+1 notes are composed
+- **THEN** the notes SHALL reference ADR-0007 with a brief summary of the decision and its stakeholder impact
+
+#### Scenario: No new ADRs since last release
+- **GIVEN** no ADRs were accepted between ecosystem releases
+- **WHEN** ecosystem release notes are composed
+- **THEN** the architecture decisions section SHALL be omitted from the release notes

--- a/openspec/changes/release-communication-strategy/tasks.md
+++ b/openspec/changes/release-communication-strategy/tasks.md
@@ -1,0 +1,65 @@
+## 1. Problem Documentation (complytime repo)
+
+- [ ] 1.1 Write problem doc `docs/problems/release-communication.md` covering the version label perception gap, multi-repo coordination challenge, unpredictable release cadence, and the missing downstream translation layer. Reference existing architecture.md and ADRs for context.
+- [ ] 1.2 [P] Update `docs/_sidebar.md` to include the new problem doc under the Problems section.
+- [ ] 1.3 [P] Update `README.md` "What's here" section to reference the new problem doc.
+
+## 2. Architecture Decision Record (complytime repo)
+
+- [ ] 2.1 Write ADR `docs/ADRs/0007-ecosystem-release-strategy.md` documenting the decision to proceed with complyctl v1.0.0, the risk assessment for API stability, the four-tier capability maturity model (Alpha/Beta/Pre-GA/GA), and the ecosystem release process triggered from the complytime repo. Follow the template in `docs/ADRs/adr-template.md`.
+- [ ] 2.2 [P] Update `docs/_sidebar.md` to include ADR-0007.
+- [ ] 2.3 [P] Update `README.md` "What's here" section to reference ADR-0007.
+
+## 3. Compatibility Matrix (complytime repo)
+
+- [ ] 3.1 Create `docs/guides/compatibility-matrix.md` with the initial matrix content: capability-oriented rows, maturity levels, validated component versions, last validated date, maturity level definitions, introductory context about release cadence, and footnote about newer versions possibly existing outside the matrix.
+- [ ] 3.2 [P] Update `docs/_sidebar.md` to include the compatibility matrix under Guides with prominent placement.
+- [ ] 3.3 [P] Update `README.md` to reference the compatibility matrix.
+- [ ] 3.4 Verify the matrix renders correctly on complytime.dev via Docsify.
+
+## 4. Breaking Change Policy (complytime repo)
+
+- [ ] 4.1 Create `docs/guides/breaking-change-policy.md` covering: rules for v1.x API stability (interface method additions, struct field changes, function signatures, enum values, proto field numbers), the three-layer CI enforcement model with detection mapping table, existing safeguards inventory with explanations, the maintainer override escape hatch (requiring approval from at least two maintainers), and links to ADR-0004 and ADR-0006.
+- [ ] 4.2 [P] Update `docs/_sidebar.md` to include the breaking change policy under Guides.
+- [ ] 4.3 [P] Update `README.md` to reference the breaking change policy.
+
+## 5. Ecosystem Release Process Guide (complytime repo)
+
+- [ ] 5.1 Create `docs/guides/ecosystem-release-process.md` covering: the release process steps (trigger, gather highlights, update matrix, compose release notes, publish, tag), the `release-highlight` label convention with examples, the capability-oriented release notes template, the tagging convention for ecosystem releases (date-based, e.g., `ecosystem-2026.07`), minimum validation criteria for matrix entries, and the requirement to reference recent ADRs in release notes.
+- [ ] 5.2 [P] Update `docs/_sidebar.md` to include the ecosystem release process guide.
+- [ ] 5.3 [P] Update `README.md` to reference the ecosystem release process guide.
+
+## 6. Release Highlight Label Setup (cross-repo)
+
+- [ ] 6.1 [P] Create the `release-highlight` label in the complytime GitHub org repositories: complyctl, complytime-providers, complytime-policies, complypack, org-infra.
+- [ ] 6.2 [P] Add a brief note about the `release-highlight` label to each repository's CONTRIBUTING.md or PR template, linking to the ecosystem release process guide on complytime.dev.
+
+## 7. Breaking Change CI - Layer 2: apidiff (complyctl repo)
+
+- [ ] 7.1 Add `apidiff` as a CI dependency in the complyctl repository (golang.org/x/exp/cmd/apidiff or equivalent; verify current recommended tool at implementation time).
+- [ ] 7.2 Create a CI job that runs apidiff comparing `pkg/provider` and `api/plugin` against the latest release tag on every PR.
+- [ ] 7.3 Configure the CI job to report breaking changes as a check failure with clear output indicating which exported symbols changed and how.
+- [ ] 7.4 Document the maintainer override process for intentional breaking changes (e.g., a specific PR label or review approval that allows merging despite the check failure). Override requires approval from at least two maintainers.
+- [ ] 7.5 Validate the apidiff CI job by submitting a test PR with a known non-breaking change (verify pass) and a known breaking change to the Provider interface (verify fail).
+
+## 8. Breaking Change CI - Layer 3: Integration Wire Test (complyctl repo)
+
+- [ ] 8.1 Design the integration wire test job: build provider binaries from the latest complytime-providers release tag, run them against the current complyctl PR branch, verify Describe/Generate/Scan RPCs succeed. Define fallback behavior if no provider release tags exist or the latest tag is unbuildable.
+- [ ] 8.2 Evaluate using the existing `test-provider` and `behavioral-report` commands as foundations for the integration test.
+- [ ] 8.3 Implement the integration wire test CI job.
+- [ ] 8.4 Validate the CI job by testing with a known-compatible provider version and verifying it passes.
+
+## 9. Short-Term: v1.0.0 Release (complyctl repo, by agreed stable release date)
+
+- [ ] 9.1 Cut v1.0.0-rc.1 release of complyctl.
+- [ ] 9.2 Coordinate stakeholder testing period with the RC release.
+- [ ] 9.3 Review API surface for any remaining concerns before v1.0.0 commitment.
+- [ ] 9.4 Cut v1.0.0 stable release of complyctl.
+- [ ] 9.5 Trigger the first ecosystem release from the complytime repo: populate the initial compatibility matrix, compose ecosystem release notes, tag the repo, and publish to complytime.dev.
+- [ ] 9.6 Communicate the ecosystem release to stakeholders using the capability-oriented format defined in the ecosystem release process guide (Task 5.1).
+
+## 10. Glossary Update (complytime repo)
+
+- [ ] 10.1 Update `docs/glossary.md` with a "Process Terms" section defining: ecosystem release, compatibility matrix, capability maturity level (Alpha/Beta/Pre-GA/GA), Pre-GA, and release highlight.
+- [ ] 10.2 [P] Update `docs/_sidebar.md` if the glossary section needs structural changes.
+<!-- spec-review: passed -->

--- a/openspec/changes/release-communication-strategy/tasks.md
+++ b/openspec/changes/release-communication-strategy/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Problem Documentation (complytime repo)
 
-- [ ] 1.1 Write problem doc `docs/problems/release-communication.md` covering the version label perception gap, multi-repo coordination challenge, unpredictable release cadence, and the missing downstream translation layer. Reference existing architecture.md and ADRs for context.
-- [ ] 1.2 [P] Update `docs/_sidebar.md` to include the new problem doc under the Problems section.
-- [ ] 1.3 [P] Update `README.md` "What's here" section to reference the new problem doc.
+- [x] 1.1 Write problem doc `docs/problems/release-communication.md` covering the version label perception gap, multi-repo coordination challenge, unpredictable release cadence, and the missing downstream translation layer. Reference existing architecture.md and ADRs for context.
+- [x] 1.2 [P] Update `docs/_sidebar.md` to include the new problem doc under the Problems section.
+- [x] 1.3 [P] Update `README.md` "What's here" section to reference the new problem doc.
 
 ## 2. Architecture Decision Record (complytime repo)
 
-- [ ] 2.1 Write ADR `docs/ADRs/0007-ecosystem-release-strategy.md` documenting the decision to proceed with complyctl v1.0.0, the risk assessment for API stability, the four-tier capability maturity model (Alpha/Beta/Pre-GA/GA), and the ecosystem release process triggered from the complytime repo. Follow the template in `docs/ADRs/adr-template.md`.
-- [ ] 2.2 [P] Update `docs/_sidebar.md` to include ADR-0007.
-- [ ] 2.3 [P] Update `README.md` "What's here" section to reference ADR-0007.
+- [x] 2.1 Write ADR `docs/ADRs/0007-ecosystem-release-strategy.md` documenting the decision to proceed with complyctl v1.0.0, the risk assessment for API stability, the four-tier capability maturity model (Alpha/Beta/Pre-GA/GA), and the ecosystem release process triggered from the complytime repo. Follow the template in `docs/ADRs/adr-template.md`.
+- [x] 2.2 [P] Update `docs/_sidebar.md` to include ADR-0007.
+- [x] 2.3 [P] Update `README.md` "What's here" section to reference ADR-0007.
 
 ## 3. Compatibility Matrix (complytime repo)
 
-- [ ] 3.1 Create `docs/guides/compatibility-matrix.md` with the initial matrix content: capability-oriented rows, maturity levels, validated component versions, last validated date, maturity level definitions, introductory context about release cadence, and footnote about newer versions possibly existing outside the matrix.
-- [ ] 3.2 [P] Update `docs/_sidebar.md` to include the compatibility matrix under Guides with prominent placement.
-- [ ] 3.3 [P] Update `README.md` to reference the compatibility matrix.
+- [x] 3.1 Create `docs/guides/compatibility-matrix.md` with the initial matrix content: capability-oriented rows, maturity levels, validated component versions, last validated date, maturity level definitions, introductory context about release cadence, and footnote about newer versions possibly existing outside the matrix.
+- [x] 3.2 [P] Update `docs/_sidebar.md` to include the compatibility matrix under Guides with prominent placement.
+- [x] 3.3 [P] Update `README.md` to reference the compatibility matrix.
 - [ ] 3.4 Verify the matrix renders correctly on complytime.dev via Docsify.
 
 ## 4. Breaking Change Policy (complytime repo)
 
-- [ ] 4.1 Create `docs/guides/breaking-change-policy.md` covering: rules for v1.x API stability (interface method additions, struct field changes, function signatures, enum values, proto field numbers), the three-layer CI enforcement model with detection mapping table, existing safeguards inventory with explanations, the maintainer override escape hatch (requiring approval from at least two maintainers), and links to ADR-0004 and ADR-0006.
-- [ ] 4.2 [P] Update `docs/_sidebar.md` to include the breaking change policy under Guides.
-- [ ] 4.3 [P] Update `README.md` to reference the breaking change policy.
+- [x] 4.1 Create `docs/guides/breaking-change-policy.md` covering: rules for v1.x API stability (interface method additions, struct field changes, function signatures, enum values, proto field numbers), the three-layer CI enforcement model with detection mapping table, existing safeguards inventory with explanations, the maintainer override escape hatch (requiring approval from at least two maintainers), and links to ADR-0004 and ADR-0006.
+- [x] 4.2 [P] Update `docs/_sidebar.md` to include the breaking change policy under Guides.
+- [x] 4.3 [P] Update `README.md` to reference the breaking change policy.
 
 ## 5. Ecosystem Release Process Guide (complytime repo)
 
-- [ ] 5.1 Create `docs/guides/ecosystem-release-process.md` covering: the release process steps (trigger, gather highlights, update matrix, compose release notes, publish, tag), the `release-highlight` label convention with examples, the capability-oriented release notes template, the tagging convention for ecosystem releases (date-based, e.g., `ecosystem-2026.07`), minimum validation criteria for matrix entries, and the requirement to reference recent ADRs in release notes.
-- [ ] 5.2 [P] Update `docs/_sidebar.md` to include the ecosystem release process guide.
-- [ ] 5.3 [P] Update `README.md` to reference the ecosystem release process guide.
+- [x] 5.1 Create `docs/guides/ecosystem-release-process.md` covering: the release process steps (trigger, gather highlights, update matrix, compose release notes, publish, tag), the `release-highlight` label convention with examples, the capability-oriented release notes template, the tagging convention for ecosystem releases (date-based, e.g., `ecosystem-2026.07`), minimum validation criteria for matrix entries, and the requirement to reference recent ADRs in release notes.
+- [x] 5.2 [P] Update `docs/_sidebar.md` to include the ecosystem release process guide.
+- [x] 5.3 [P] Update `README.md` to reference the ecosystem release process guide.
 
 ## 6. Release Highlight Label Setup (cross-repo)
 
@@ -60,6 +60,6 @@
 
 ## 10. Glossary Update (complytime repo)
 
-- [ ] 10.1 Update `docs/glossary.md` with a "Process Terms" section defining: ecosystem release, compatibility matrix, capability maturity level (Alpha/Beta/Pre-GA/GA), Pre-GA, and release highlight.
-- [ ] 10.2 [P] Update `docs/_sidebar.md` if the glossary section needs structural changes.
+- [x] 10.1 Update `docs/glossary.md` with a "Process Terms" section defining: ecosystem release, compatibility matrix, capability maturity level (Alpha/Beta/Pre-GA/GA), Pre-GA, and release highlight.
+- [x] 10.2 [P] Update `docs/_sidebar.md` if the glossary section needs structural changes.
 <!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

Proposes and implements an ecosystem-level release communication strategy to address the misalignment between Go semver pre-release conventions and stakeholder expectations across the complytime multi-repo ecosystem.

Originated from an exploratory discussion between @gvauter, @jflowers, @jpower432, and @marcusburghardt.

## What's Included

### Documentation Artifacts

| Artifact | Path | Purpose |
|---|---|---|
| Problem doc | `docs/problems/release-communication.md` | Explores why release communication is hard in a multi-repo Go ecosystem |
| ADR-0007 | `docs/ADRs/0007-ecosystem-release-strategy.md` | Decision to proceed with v1.0.0, adopt capability maturity model, establish ecosystem release process |
| Compatibility matrix | `docs/guides/compatibility-matrix.md` | Capability-oriented matrix with maturity levels (Alpha/Beta/Pre-GA/GA) |
| Breaking change policy | `docs/guides/breaking-change-policy.md` | Rules for v1.x API stability with three-layer CI enforcement model |
| Release process guide | `docs/guides/ecosystem-release-process.md` | Maintainer-triggered process for ecosystem-wide release coordination |
| Glossary update | `docs/glossary.md` | New Process Terms section with ecosystem release vocabulary |

### Key Decisions (ADR-0007)

1. Proceed with complyctl v1.0.0 — API surface is stable, risk is low
2. Four-tier capability maturity model (Alpha/Beta/Pre-GA/GA) decoupled from component versions
3. Ecosystem release process triggered from the complytime repo as maintainer sign-off
4. Compatibility matrix on complytime.dev
5. Three-layer breaking change CI enforcement (Buf, apidiff, integration wire test)

### Cross-Repo Tasks (not in this PR)

Tasks 6-9 in the task list are tracked separately in their target repositories:
- `release-highlight` label setup across org repos
- apidiff CI and integration wire test in complyctl
- v1.0.0 release engineering

## Cleanup Note

The `openspec/changes/release-communication-strategy/` directory contains the planning artifacts (proposal, design, specs, tasks) used to develop this change. These files can be removed once the documentation in `docs/` has been reviewed and merged, to keep the repository structure clean per the conventions in AGENTS.md.