### PR TITLE
ci: add auto-labeler for PRs by directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+problem:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/problems/**'
+
+adr:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/ADRs/**'
+
+guide:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/guides/**'
+
+plan:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/plans/**'
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '*.md'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0


### PR DESCRIPTION
## Summary
- Adds `actions/labeler@v6.1.0` workflow to auto-label PRs based on changed directories
- Labels: `problem`, `adr`, `guide`, `plan`, `docs`, `ci`
- Action pinned to commit SHA, least-privilege permissions scoped to job level

## Test plan
- [ ] Open a PR touching `docs/problems/` and verify it gets `problem` + `docs` labels
- [ ] Open a PR touching `.github/` and verify it gets `ci` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)