### PR TITLE
docs: add problem doc and PR chaining conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,8 @@ When contributing to this repo:
 - **ADRs are immutable.** Never edit an accepted ADR. Supersede it with a new one.
 - **Keep the sidebar current.** Update `docs/_sidebar.md` when adding new documents.
 - **Link new docs in the README.** The "What's here" section in `README.md` is the entry point.
+- **Problem docs have no decisions.** Problem docs may contain "Proposed approaches" for exploration, but settled decisions must be extracted to ADRs before merge. Sections titled "Decisions", "Settled questions", or "Resolution status" in problem docs are a review blocker.
+- **One logical change per PR.** Do not bundle unrelated document changes. If a problem exploration leads to a decision, the decision goes in a chained ADR PR, not the same PR.
+- **Chain PRs for problem → ADR pairs.** The problem doc PR targets main. The ADR PR targets the problem doc branch. GitHub shows the dependency. Reviewers can approve the problem doc independently.
+- **Evidence semantics belong in Gemara.** Problem docs describe *why* evidence is hard. Schema-level semantics (freshness models, confidence descriptors, envelope schemas) belong in the Gemara repository, not in problem docs.
+- **Vendor-neutral problem statements.** Problem docs describe approaches generically. Specific vendor/product names belong in "Current approaches / prior art" sections, not in proposed approaches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,11 @@ Problem docs explore a technical domain. They are living documents — expect th
 Structure (suggested, not mandatory):
 1. Why this is hard
 2. Current approaches / prior art
-3. Proposed approaches with trade-offs
+3. Proposed approaches with trade-offs (exploratory — no settled decisions)
 4. Open questions
+5. Cross-references
+
+Do not include a "Decisions" section. When exploration settles a question, extract it to an ADR in a chained PR.
 
 Do not worry about "finishing" a problem doc. Partial explorations with open questions are valuable.
 


### PR DESCRIPTION
## Summary

docs: add problem doc and PR chaining conventions to AGENTS.md

Codify review feedback patterns: no decisions in problem docs, one
logical change per PR, chain problem→ADR PRs, evidence semantics
belong in Gemara, vendor-neutral problem statements.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>

docs: address PR #11 review feedback (#15)

* docs: address PR #11 review feedback

Add directory structure to AGENTS.md, include complytime-collector-components
in CONTRIBUTING.md, add "How" section to vision with maturity distinction,
add example links to glossary, clarify runtime client plugin boundary in
architecture, add sidebar maintenance reminder, add ADR approval process
reference, create complypack-phase1 stub, and remove retired ceps/.

Closes #14

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>