### PR TITLE
docs: add ADR-0008 evaluator interface contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo is a living design document exploring how compliance assessment become
   - [Evaluator Coupling](docs/problems/evaluator-coupling.md) — Verification logic tied to specific tools and runtimes
   - [Cross-Framework Mapping](docs/problems/cross-framework-mapping.md) — Overlapping requirements across standards with no machine-readable mapping
   - [Evidence](docs/problems/evidence.md) — Fragmented, manual, and opaque compliance evidence
+  - [System Modeling and Drift](docs/problems/system-modeling-and-drift.md) — Knowing what you're assessing when infrastructure is dynamic
 - **[docs/plans/](docs/plans/)** — Implementation plans for accepted designs
 - **[docs/ADRs/](docs/ADRs/)** — Architecture Decision Records for crystallized decisions
 - **[docs/guides/](docs/guides/)** — Practical how-to documentation

--- a/docs/ADRs/0008-evaluator-interface-contract.md
+++ b/docs/ADRs/0008-evaluator-interface-contract.md
@@ -1,0 +1,32 @@
+# ADR-0008: Evaluator Interface Contract
+
+**Status:** proposed
+
+**Date:** 2026-06-24
+
+**Deciders:** ComplyTime maintainers
+
+## Context
+
+The [evaluator-coupling](../problems/evaluator-coupling.md) problem doc identifies four open questions about how evaluators interact with the platform. The [system-modeling-and-drift](../problems/system-modeling-and-drift.md) problem doc proposes the property graph as the primary data substrate. [ADR-0004](0004-grpc-provider-plugin-architecture.md) established gRPC as the plugin protocol but did not specify what crosses the wire (what the platform sends to evaluators and what evaluators return. This ADR fills that gap.
+
+## Decision
+
+This decision has three parts.
+
+**Engine diversity is accepted.** Evaluation logic stays engine-native. The platform does not define a portable evaluation language or DSL. Evaluator authors work in whatever language their engine requires: Rego, OVAL, CEL, Ruby DSL, Python, or custom logic. The platform owns routing (discovering and dispatching to evaluators), orchestration (managing evaluation lifecycle), and result unification (normalizing findings into a common evidence format).
+
+**Default interface is message-passing with opt-in graph access.** The platform sends each evaluator a scoped payload containing the system state relevant to its check. Evaluators return structured findings. This is the default and only interface for most evaluators. 
+
+Evaluators that require cross-entity reasoning (checks spanning multiple system components) can request graph access. The platform grants read-only access to an explicitly scoped subgraph. Graph access requires authorization, since evaluators are untrusted by default. The scope, duration, and audit trail of graph access are platform-controlled.
+
+**Composition ownership is split between requirement and content.** When a requirement spans multiple evaluation forms (intent and behavioral, automated and manual), the requirement model (Gemara) declares what evaluation forms are needed. The assessment logic stream ([ADR-0005](0005-two-stream-content-model.md)'s second content stream) declares how to compose the results of specific checks (both-must-pass, either-suffices, behavioral-overrides-intent, or custom logic. The Runtime Client's Scan component executes these composition rules but does not define them.
+
+## Consequences
+
+- Evaluator authors write checks in their native language; no transpilation or abstraction layer to build or maintain.
+- The platform must define a scoped-payload schema (what the platform sends) and a findings-return schema (what evaluators return). These schemas are not defined in this ADR and will require their own design work.
+- Graph access grants need an authorization model: scope definition, read-only enforcement, and audit trail.
+- Composition rules become a first-class artifact in the assessment logic content stream.
+- The Gemara requirement model needs a field for declaring required evaluation forms.
+- The Runtime Client's merge logic must support pluggable composition rulesbeyond simple aggregation.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -20,3 +20,4 @@
   - [0004 gRPC Provider Plugin Architecture](ADRs/0004-grpc-provider-plugin-architecture.md)
   - [0005 Two-Stream Content Model](ADRs/0005-two-stream-content-model.md)
   - [0006 ComplyPack Content Envelope](ADRs/0006-complypack-content-envelope.md)
+  - [0008 Evaluator Interface Contract](ADRs/0008-evaluator-interface-contract.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
   - [Evaluator Coupling](problems/evaluator-coupling.md)
   - [Cross-Framework Mapping](problems/cross-framework-mapping.md)
   - [Evidence](problems/evidence.md)
+  - [System Modeling and Drift](problems/system-modeling-and-drift.md)
 
 - **Plans**
   - [ComplyPack Phase 0](plans/complypack-phase0.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Component vocabulary for ComplyTime. This document names the functional roles and describes how they relate — not how they work internally or which repositories implement them.
+Component vocabulary for ComplyTime. This document names the functional roles and describes how they relate (not how they work internally or which repositories implement them.
 
 ## Component Map
 
@@ -63,11 +63,11 @@ Distributes two independent streams: compliance content (what must be true) and 
 
 ### Runtime Client
 
-Pulls content, resolves policies, discovers evaluators, orchestrates scans, merges results. The core client routes evaluator content by metadata without interpreting it. Evaluator plugins within the client boundary handle the mapping between evaluator-specific results and the common evidence model.
+Pulls content, resolves policies, discovers evaluators, orchestrates scans, merges results. Never interprets evaluator-specific content — routes by metadata only.
 
 ### Evaluators
 
-Standalone processes that perform data collection and evaluation. Each evaluator owns its collection and evaluation logic entirely. The runtime client never participates in evaluation.
+Standalone processes that receive scoped system-state payloads from the Runtime Client and return structured findings. Each evaluator owns its evaluation logic in its native engine language. The default interface is message-passing; evaluators requiring cross-entity reasoning can request read-only access to a scoped subgraph of the property graph. The Runtime Client never participates in evaluation. See [ADR-0008](ADRs/0008-evaluator-interface-contract.md) for the interface contract.
 
 ### Evidence Platform
 
@@ -100,5 +100,6 @@ Supporting repositories: [complypack](https://github.com/complytime/complypack) 
 |:--------------|:------------------|:------------------|:--------------------|
 | Distribution  | Content registry  | Runtime client    | Content pull        |
 | Orchestration | Runtime client    | Evaluators        | Plugin interface    |
+| Graph access  | Runtime client    | Evaluators        | Scoped subgraph query (opt-in) |
 | Evidence      | Evaluators        | Evidence platform | Evidence submission |
 | Audit         | Evidence platform | Audit preparation | Evidence query      |

--- a/docs/problems/evaluator-coupling.md
+++ b/docs/problems/evaluator-coupling.md
@@ -64,3 +64,13 @@ Organizations accumulate checks. A small team starts with 20 policies. Three yea
 - What is the right boundary between "platform" (routes content to evaluators) and "evaluator" (executes checks)?
 - How do manual and automated evaluation results unify without forcing manual assessment into formats designed for machine evaluation?
 - When a requirement spans intent and behavioral evaluation, who owns the coupling between the two evaluators — the compliance engineer, the operations team, or an integration layer?
+
+## Resolution status
+
+1. **Is full evaluator independence achievable?** Resolved. Engine diversity is accepted as permanent. Data coupling is broken by the unified property graph. Logic coupling to the engine's native language is accepted and managed by the platform through routing and result unification. See [ADR-0008](../ADRs/0008-evaluator-interface-contract.md).
+
+2. **What is the right boundary between platform and evaluator?** Resolved. The platform sends scoped payloads (message-passing); evaluators return structured findings. Cross-entity graph access is opt-in with strict authorization. See [ADR-0008](../ADRs/0008-evaluator-interface-contract.md).
+
+3. **How do manual and automated evaluation results unify?** Partially resolved. Both map to requirements in the property graph. The unified evidence model is under exploration. See [evidence.md](evidence.md) for the expanded problem exploration.
+
+4. **Who owns the coupling between intent and behavioral evaluators?** Resolved. The requirement declares what evaluation forms are needed; the assessment logic declares how to compose results. The Runtime Client executes but does not define composition. See [ADR-0008](../ADRs/0008-evaluator-interface-contract.md).

--- a/docs/problems/system-modeling-and-drift.md
+++ b/docs/problems/system-modeling-and-drift.md
@@ -1,0 +1,83 @@
+# System Modeling and Drift
+
+Compliance assessment assumes you know what system you are assessing. In practice, the system under observation is a moving target. Infrastructure is provisioned dynamically, configurations drift from declared state, and the gap between what was deployed and what is running widens silently between assessment cycles.
+
+Static analysis of infrastructure-as-code (Terraform plans, Kubernetes manifests, CloudFormation templates) captures declared intent, not runtime reality. A compliant-at-deploy cluster that accumulates ad-hoc changes between scans presents a false positive to any tool that reads only the declared state. Drift detection requires comparing a model of expected state against observed state, and that requires having a model in the first place.
+
+The modeling problem has two distinct faces. First, the analytical model: a formal representation of the system's components, their relationships, data flows, and trust boundaries, suitable for reasoning about impact, risk, and attack paths. Second, the runtime inventory: a continuously updated record of what actually exists, discovered from the systems themselves. These serve different purposes but must be reconciled. The analytical model is where you reason, the runtime inventory is ground truth.
+
+Operator burden is the binding constraint. Any system modeling approach that requires engineers to manually maintain a model will fail. The model will rot as soon as operational pressure arrives. Discovery must be automated, incremental, and near-zero friction.
+
+## Current approaches and prior art
+
+### Infrastructure-as-code scanning
+
+Tools like [Checkov][checkov], tfsec, and kube-bench analyze declared configuration. They are effective for pre-deployment gates but blind to runtime drift. They operate on individual resource definitions and do not produce a system model (no relationships, no data flows, no trust boundaries). They answer "does this Terraform file violate this rule?" but not "what depends on this service?" or "what attack paths cross this boundary?"
+
+### Cloud Security Posture Management (CSPM)
+
+Commercial tools such as Prisma Cloud, Wiz, and AWS Security Hub continuously scan cloud environments and provide runtime state visibility. They detect misconfigurations, over-permissioned identities, and exposed resources. However, they are proprietary, cloud-specific, and do not produce a portable system model. The representation is internal and optimized for the vendor's analysis engine. Organizations cannot export the discovered topology to perform custom reasoning or integrate with other tools. CSPM is assessment, not modeling.
+
+### [Cartography][cartography] (CNCF)
+
+Cartography is open-source infrastructure discovery tooling that pulls asset and relationship data from cloud provider APIs and builds a [Neo4j][neo4j] graph. It is strong prior art for automated discovery: modular, extensible, and relationship-focused. It answers questions like "which EC2 instances can assume this IAM role?" or "which S3 buckets are exposed to the internet?" However, Cartography is tightly coupled to Neo4j. The graph is the runtime store, and the query language (Cypher) is the interface. Swapping the backend requires rewriting every adapter.
+
+### [FINOS CALM][finos-calm] (Common Architecture Language Model)
+
+CALM is an emerging open standard for describing system architectures as structured data. It is lighter-weight than formal modeling languages and designed for cross-organizational interchange. The project is early-stage but shows promise for a portable architecture representation that tools can consume. CALM is declarative: it captures what the architect intended, not what is running. It does not address runtime discovery or drift detection.
+
+### [SysML v2][sysml-v2]
+
+SysML (Systems Modeling Language) version 2 is an [OMG][omg] formal specification adopted in July 2025. It is an industry-standard systems modeling language with a formal semantics layer (KerML, the Kernel Modeling Language) and a Systems Modeling API for tool interoperability. SysML v2 is designed for analytical modeling of complex systems: the kind of formal analysis that safety-critical industries (aerospace, automotive, medical devices) require. It supports hierarchical decomposition, allocation of functions to components, requirement traceability, and parametric constraints. It is powerful but heavyweight. The learning curve is steep, the tooling ecosystem is nascent, and the model requires significant upfront investment.
+
+SysML v2 is intended for the kind of rigorous, traceable analysis where you need to prove properties about a system's behavior under all conditions. Compliance assessment rarely needs that level of formality, but the subset that does (verifying cryptographic properties, reasoning about isolation boundaries, proving access control invariants) would benefit from the formal semantics.
+
+### Custom inventory systems
+
+Many organizations build internal Configuration Management Databases (CMDBs) using platforms like ServiceNow, Ralph, or Nautobot. These track assets (servers, applications, contracts, owners) and support operational workflows. However, they typically lack the relationship modeling needed for impact analysis or attack path enumeration. A CMDB knows that Server A exists and belongs to Team B. It does not know that Server A can reach Database C because NetworkPolicy D allows it. CMDBs are catalogs, not models.
+
+## Proposed approaches
+
+The challenge is reconciling two competing needs: automated discovery with near-zero operator burden, and formal modeling for rigorous analysis. These are not the same artifact.
+
+### Two-layer approach
+
+A separation of concerns emerges naturally:
+
+1. **Runtime discovery layer**: automated, continuous, low-burden. Pulls system state from APIs and agents: cloud provider APIs (AWS, Azure, GCP), Kubernetes API server, network traffic analyzers, [OpenTelemetry][opentelemetry] service discovery, configuration management agents. Produces a runtime inventory in a property graph store. The discovery layer should be modular: different discovery adapters for different infrastructure types, extensible to new environments without rewriting the core. Cartography is strong prior art here and we could work with the team to optimize it and make it graph-backend agnostic. The runtime inventory is organic. Its schema is shaped by what actually exists and what queries are actually needed, not by a predefined formal model.
+
+2. **Analytical modeling layer**: formal system model for reasoning about impact, risk, and compliance relationships. SysML v2 is the most complete option for this layer. Its formal semantics enable automated reasoning that lighter approaches cannot support: proving that no data flow crosses a regulatory boundary, verifying that all paths to a sensitive resource require authentication, calculating the blast radius of a compromised component. However, the analytical model need not be the runtime store. SysML v2 (or CALM, or any modeling language) could be a projection from the property graph: an output format for analysis, not the internal representation. This avoids coupling the compliance platform to any single modeling standard while still enabling formal analysis when needed.
+
+The key design question: does the compliance graph need a formal modeling language as its internal schema, or should the internal schema be organic (shaped by actual queries and usage) with formal models as an export or analysis layer? The latter avoids coupling the platform to any single modeling standard while still enabling formal analysis when needed. The cost is translation overhead. Every formal analysis tool needs an adapter that translates from the internal graph to its expected input format.
+
+### Drift detection as a delta operation
+
+Drift detection emerges naturally from the two-layer approach. The analytical model represents expected state: the architecture as designed, possibly blessed by a compliance authority. The runtime inventory represents observed state: what actually exists. Drift is the set-theoretic difference between them.
+
+When a component appears in observed state but not in expected state, that is unplanned infrastructure. When a relationship appears in expected state but not in observed state, that is missing enforcement. When a component's attributes differ between the two, that is configuration drift. Each delta is a drift event that triggers compliance reassessment of affected controls.
+
+This requires a stable identifier scheme that links analytical model entities to runtime inventory entities. An API Gateway declared in a Terraform module and discovered from AWS APIs must map to the same logical component. Without stable identifiers, drift detection devolves into string matching heuristics that fail as soon as naming conventions change.
+
+### Minimal viable discovery
+
+The bootstrapping problem is steep. Full system discovery across every infrastructure type is a multi-year effort. What is the minimum viable discovery that imposes near-zero operator burden and delivers enough value to justify adoption?
+
+Cloud provider APIs are the lowest-friction starting point. They require no agents, no network access to internal systems, and no changes to deployment workflows. Read-only API access can discover compute instances, storage buckets, databases, identity resources, network topology, and access policies. The coverage is broad enough to support meaningful compliance checks. The blind spots (on-premises systems, third-party SaaS, physical infrastructure) can be addressed later.
+
+Kubernetes API discovery is similarly low-friction for containerized workloads. The API server is the source of truth for cluster state. No agents required. The API model is well-documented and stable. Discovery adapters for Kubernetes are well-trodden ground.
+
+Network traffic observation is higher friction. It requires agents, access to network flows (NetFlow, sFlow, packet captures), and sustained compute for analysis. The payoff is runtime behavioral data: what actually talks to what rather than only what is permitted to talk. This is essential for behavioral evaluation (see [Evaluator Coupling](evaluator-coupling.md)) but not necessary for initial discovery.
+
+## Open questions
+
+System modeling for compliance raises questions about schema representation, discovery scope, query architecture, drift semantics, ephemeral infrastructure, and abstraction depth that require architectural decisions. See [ADR-0008](../ADRs/0008-evaluator-interface-contract.md) for the evaluator interface decisions and the broader system modeling ADRs as they crystallize.
+
+See [Evaluator Coupling](evaluator-coupling.md) for how verification logic is tied to specific infrastructure types, creating the fragmentation that a unified system model could address.
+
+[checkov]: https://www.checkov.io/
+[cartography]: https://github.com/lyft/cartography
+[neo4j]: https://neo4j.com/
+[finos-calm]: https://github.com/finos/architecture-as-code
+[sysml-v2]: https://www.omg.org/spec/SysML/2.0/
+[omg]: https://www.omg.org/
+[opentelemetry]: https://opentelemetry.io/


### PR DESCRIPTION
## Summary

docs: add ADR-0008 evaluator interface contract

Engine diversity accepted, message-passing with opt-in graph access,
composition split between requirement and content layers. Updates
architecture.md evaluator description and evaluator-coupling.md
resolution status.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>

docs: add system-modeling-and-drift problem document

Explore the challenge of knowing what system you are assessing when
infrastructure is provisioned dynamically and configurations drift
from declared state. Survey IaC scanning, CSPM, Cartography, CALM,
and SysML v2. Propose a two-layer approach with runtime discovery
and analytical modeling.

Decisions extracted to ADR-0008.

**Depends on:** #18 (`docs/problem-system-modeling`)

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>