### PR TITLE
docs: add ADR-0009 property graph for compliance relationships

### DIFF
--- a/docs/ADRs/0009-property-graph.md
+++ b/docs/ADRs/0009-property-graph.md
@@ -1,0 +1,45 @@
+# ADR-0009: Property Graph for Compliance Relationships
+
+**Status:** proposed
+
+**Date:** 2026-06-22
+
+**Deciders:** complytime-dev team
+
+## Context
+
+Compliance relationships (requirements to requirements, requirements to evidence, systems to controls, controls to risk) are graph problems. A control maps to multiple requirements across frameworks. A piece of evidence satisfies controls in three standards simultaneously. A system change ripples through controls, evidence, and authorization decisions.
+
+Spreadsheet-based mapping is the current norm. It does not scale, cannot be queried programmatically, and loses the reasoning behind relationships. Relational schemas can model some relationships, but traversal queries (impact analysis: "if this control changes, what authorizations are affected?"; traceability chains: "show me the full path from authority document to evidence"; attack path enumeration: "what is the shortest path from this exposure to sensitive data?") are unnatural in SQL, degrade as join depth increases, and become intractable to "desire path" driven change.
+
+Compliance data is also inherently distributed. Different organizations, departments, and programs own different parts of the picture. A single centralized graph cannot hold all of it: sovereignty rules prohibit sending classified or proprietary controls across ownership boundaries, and governance breaks down when a global graph must represent conflicting but jurisdictionally valid interpretations of the same framework. The graph architecture must accommodate federation from the start by sharing generic, framework-level knowledge while structurally preventing leakage of proprietary requirements, classified controls, and evidence.
+
+The domain needs a data store where relationships are first-class, richly attributed (typed, scored, temporally bounded, provenanced), and efficiently traversable at arbitrary depth, and where sovereignty boundaries are a structural property of the schema, not a policy overlay.
+
+See the [Cross-Framework Mapping](../problems/cross-framework-mapping.md), [Evidence](../problems/evidence.md), and [Federated Compliance Graphs](../problems/federated-compliance-graphs.md) problem docs for the domain exploration behind this decision.
+
+## Decision
+
+Adopt a property graph queried via [GQL](https://www.iso.org/standard/76120.html) (ISO/IEC 39075:2024) as the relationship layer for compliance data. GQL is the ISO standard for property graph queries, a declarative, pattern-matching language that drew from openCypher, PGQL, and G-CORE. The companion standard [SQL/PGQ](https://www.iso.org/standard/84803.html) (ISO 9075-16) embeds graph pattern matching inside SQL; GQL is a superset.
+
+The property graph runs inside [PostgreSQL](https://www.postgresql.org/) using [Apache AGE](https://age.apache.org/), alongside relational data (PostgreSQL native) and vector similarity ([pgvector](https://github.com/pgvector/pgvector)). One database engine serves three data patterns. AGE currently implements openCypher, not GQL. Because openCypher is a semantic predecessor of GQL and the industry is converging (Neo4j's Cypher 10 tracks GQL alignment), queries written against AGE today should migrate to GQL with bounded effort as engine support matures. The target standard is GQL; openCypher via AGE is the pragmatic starting point.
+
+The graph is the system of record for relationships. Projections to external systems (analytics engines, visualization tools, SIEMs, reporting platforms) are optimization, not authority. A projected copy is a cache; the graph is truth.
+
+The graph schema must distinguish between generic framework-level knowledge (how public standards relate to each other) and proprietary or classified data (organization-specific requirements, evidence, system models). Generic mappings are exportable and federatable; proprietary nodes and edges are not serializable across sovereignty boundaries. This distinction is enforced at the schema level. Edge and node types carry sovereignty metadata that determines what can cross a boundary, not by runtime access control alone.
+
+The internal graph schema is driven by query needs and actual usage patterns, not by any external modeling language. Schema evolution is organic: new node types, edge types, and properties are added as real queries demand them, with periodic grooming to maintain coherence. Formal modeling languages ([SysML v2](https://www.omg.org/spec/SysML/2.0/), [CALM](https://github.com/finos/architecture-as-code), RDF) may be used as export/analysis formats but do not dictate the internal schema.
+
+RDF is deferred while the data model is experimental. The property graph model (labeled nodes and edges with arbitrary key-value properties) is more natural for a schema that is still forming. If the schema stabilizes and the domain would benefit from formal ontology reasoning, migration to RDF remains possible.
+
+## Consequences
+
+- GQL (ISO/IEC 39075:2024) is the target query language for traversal across requirements, evidence, systems, and risk. As an ISO standard, it provides stronger long-term stability than any single-vendor language.
+- openCypher via Apache AGE is the initial implementation. AGE does not yet support GQL. This creates a migration obligation: queries written against openCypher today must be ported when AGE (or a replacement engine) adds GQL support. The migration risk is bounded because openCypher is a semantic subset of GQL and the syntactic differences are incremental.
+- Single-engine deployment (PostgreSQL + AGE + pgvector) reduces operational complexity compared to running separate graph, relational, and vector databases.
+- Apache AGE is a top-level Apache Software Foundation project with an active community and PostgreSQL-native integration.
+- Schema-level sovereignty metadata enables federation without centralization. Each deployment owns its graph; generic framework mappings can be shared across boundaries while proprietary data stays local. The federation design is explored in the [Federated Compliance Graphs](../problems/federated-compliance-graphs.md) problem doc; specific federation protocols are deferred pending implementation experience.
+- Schema evolution is organic; no upfront modeling exercise required. This is a deliberate trade-off: faster iteration at the cost of potential inconsistency, mitigated by grooming cycles.
+- RDF deferral means no formal ontology reasoning until the schema stabilizes. Acceptable for an experimental data model; revisit if the domain demands it.
+- GQL is a graph-specific query language. Teams familiar with SQL but not graph queries face a learning curve. AGE allows mixing Cypher and SQL in the same query, easing transition. SQL/PGQ provides an additional on-ramp for teams that prefer to embed graph patterns inside SQL SELECT statements.
+- Vendor optionality: GQL is an ISO standard supported by multiple engines. Migrating from PostgreSQL+AGE to another GQL-compatible engine is feasible if AGE hits scale limits or GQL adoption accelerates elsewhere.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
   - [Evaluator Coupling](problems/evaluator-coupling.md)
   - [Cross-Framework Mapping](problems/cross-framework-mapping.md)
   - [Evidence](problems/evidence.md)
+  - [Federated Compliance Graphs](problems/federated-compliance-graphs.md)
 
 - **Plans**
   - [ComplyPack Phase 0](plans/complypack-phase0.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -20,3 +20,4 @@
   - [0004 gRPC Provider Plugin Architecture](ADRs/0004-grpc-provider-plugin-architecture.md)
   - [0005 Two-Stream Content Model](ADRs/0005-two-stream-content-model.md)
   - [0006 ComplyPack Content Envelope](ADRs/0006-complypack-content-envelope.md)
+  - [0009 Property Graph](ADRs/0009-property-graph.md)

--- a/docs/problems/federated-compliance-graphs.md
+++ b/docs/problems/federated-compliance-graphs.md
@@ -1,0 +1,48 @@
+# Federated Compliance Graphs
+
+Compliance data is inherently distributed. Different organizations, departments, and programs own different parts of the picture, and a single centralized graph cannot hold all of it. Sovereignty rules prohibit sending classified or proprietary controls across ownership boundaries. Governance breaks down when a global graph must represent conflicting but jurisdictionally valid interpretations of the same framework. Scale limits emerge when a single store spans organizations that trust each other only conditionally.
+
+At the same time, the value of compliance mapping increases with network effects. Organizations that map the same frameworks independently waste collective effort. The architectural problem: share generic, framework-level knowledge (how public standards relate to each other) while structurally preventing leakage of proprietary requirements, classified controls, and evidence. This is a federation problem, not an access control problem.
+
+## Current approaches and prior art
+
+Teams share mapping spreadsheets ad-hoc between auditors, consultants, and compliance staff. No structure, no versioning, no provenance, no way to reconcile conflicting versions. A mapping spreadsheet that works for one organization's interpretation of a framework may be subtly wrong for another's. There is no trace of who originated the mapping, under what interpretation, or when it was last validated. Spreadsheets scale to tens of mappings but collapse under hundreds.
+
+Commercial GRC tools provide tenant isolation but within a single vendor's platform. Data sovereignty depends entirely on vendor trust. The vendor hosts your proprietary requirements alongside everyone else's. The platform promises logical separation, but the data lives in the vendor's infrastructure, subject to the vendor's jurisdiction, subpoena risk, and operational policies. No federation between instances. If two organizations both use the same GRC platform but want to share generic framework mappings without exposing proprietary data, they cannot. The platform was not designed for peer-to-peer federation.
+
+The Open Security Architecture (OSA) project maintains a repository of security architecture patterns and control mappings. Publicly available but manually curated, no machine-readable API, and the project maintains that human curation is superior to automation. OSA provides valuable reference mappings but cannot scale to the full combinatorial space of framework-to-framework relationships. It covers the most common pairings (NIST to ISO, CIS to NIST) but does not address how an organization extends those mappings with proprietary controls or how to federate proprietary extensions without centralizing them.
+
+NIST maintains the National Cybersecurity Online Informative References ([OLIR](https://csrc.nist.gov/projects/olir)), a mapping repository between frameworks. Authoritative for the mappings it covers but limited in scope, manually maintained, and not designed for bidirectional community contribution. OLIR is read-only for most users. Organizations can consume the mappings but cannot contribute corrections or extensions back into the commons without going through NIST's publication process. This works for stable, slowly-evolving frameworks but does not support the continuous feedback loop that a living compliance mapping ecosystem requires.
+
+Academic and industry work on federating knowledge graphs (SPARQL federation, linked data, semantic web standards) is technically mature but not applied to compliance specifically. Relevant patterns: query federation (route queries across boundaries without copying data), data virtualization (expose a unified view without centralizing storage), and selective replication (sync chosen subsets of a graph between federated nodes). The challenge is adapting these patterns to compliance's unique sovereignty and trust requirements. Not all data is equal, and not all boundaries are symmetrical.
+
+## Proposed approaches
+
+Explore a federated meta-graph architecture where sovereignty is a structural property, not a policy overlay:
+
+Each area of responsibility owns its own property graph, its own security boundary, and its own rules about what is visible and to whom. A classified government program maintains an air-gapped graph with zero external connectivity. A regulated financial institution maintains a private graph behind firewall and VPN. An open-source community maintains a public graph accessible to all. The same architecture serves all three scenarios without special-casing any of them.
+
+A federation layer knits these graphs into a navigable meta-graph. The meta-graph carries only generic, framework-level knowledge: how [NIST 800-53](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final) maps to [ISO 27001](https://www.iso.org/standard/27001), how [CIS Controls](https://www.cisecurity.org/controls) relate to SOC 2, how [PCI-DSS](https://www.pcisecuritystandards.org/) overlaps with GDPR. Proprietary requirements, classified controls, and evidence never cross the owner's boundary. The boundary is enforced by the graph schema itself: edges that represent generic framework mappings are exportable; edges that represent proprietary implementations are not. The architecture makes it impossible to accidentally leak proprietary data because the schema does not permit those relationships to traverse federation boundaries.
+
+The same architecture serves diverse deployment scenarios without forking the design:
+
+- Air-gapped deployment: fully isolated, zero external dependencies. The graph contains classified controls and proprietary system models. The deployment syncs with the commons only if and when its owner chooses, via one-way import of generic framework mappings on removable media or during scheduled sync windows. The air-gapped node can contribute mappings back to the commons through the same mechanism, but only after declassification review.
+
+- Regulated organization: controlled connectivity, selective sharing. The graph contains proprietary risk models and audit evidence that must stay within the organization's boundary. The deployment federates with the commons for generic framework mappings but exports nothing proprietary. The organization benefits from community-vetted mappings and contributes corrections back to the commons when it discovers errors, but its internal requirements never leave its boundary.
+
+- Open community: full participation in the commons. The graph contains only public framework definitions and community-contributed mappings. All nodes are readable by anyone. The community reviews, corrects, flags, and votes on mappings. Every interaction is labeled data that improves the mapping engine over time.
+
+The community commons model: organizations publish the generic mappings they choose to share. The community reviews, corrects, flags, and votes on them. An arbiter (domain expert, standards body, or delegated authority) blesses accepted mappings. The commons does not replace authoritative sources like NIST OLIR; it complements them by covering the long tail of framework pairings that no single authority can maintain. The commons is a feedback loop: organizations consume vetted mappings, discover errors or gaps in practice, and contribute corrections back.
+
+Sovereignty is a structural property, not a policy. The architecture must enforce boundary rules by construction, not by trusting participants to obey access control lists. What crosses a boundary is always a generic mapping (how two public frameworks relate), never a proprietary requirement or piece of evidence. The schema enforces this: proprietary nodes and edges are not serializable across federation boundaries. An attempt to export them fails at the type level, not at runtime after the data has already leaked.
+
+## Open questions
+
+Federation introduces questions about trust governance, sovereignty enforcement, sync mechanisms, and query performance that require architectural decisions. See [ADR-0009](../ADRs/0009-property-graph.md) for the property graph decision and [ADR-0012](../ADRs/0012-federated-graph-sovereignty.md) for the federation governance decisions that have crystallized from this exploration.
+
+## See also
+
+- [Cross-Framework Mapping](cross-framework-mapping.md): the mapping problem federation distributes
+- [Requirement Fidelity](requirement-fidelity.md): how meaning is preserved across boundaries
+- [Evaluator Coupling](evaluator-coupling.md): how tool-specific logic affects evidence collection
+- [Evidence](evidence.md): fragmented, manual, and opaque compliance evidence


### PR DESCRIPTION
## Summary

docs: add ADR-0009 property graph for compliance relationships

Adopt a property graph queried via GQL (ISO 39075:2024) as the
relationship layer. openCypher via Apache AGE is the pragmatic
starting point. Runs in PostgreSQL alongside pgvector.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>

docs: add federated compliance graphs problem document

Define the problem of sharing compliance mapping data across sovereign
boundaries. Survey prior art and propose a federated meta-graph
architecture where sovereignty is structural, not policy.

Decisions extracted to ADR-0009 and ADR-0012.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>

**Depends on:** #21 (`docs/problem-federated-graphs`)

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>