### PR TITLE
chore: update CODEOWNERS to change approvers group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repo.
-* @complytime/complytime-approvers
+* @complytime/architecture-advisory-council


### PR DESCRIPTION
## Summary

Update CODEOWNERS from `complytime-approvers` to newly established AAC group

## Related Issues

N/A

## Review Hints

N/A
